### PR TITLE
Empty response handling in serving api

### DIFF
--- a/serving/src/main/java/feast/serving/grpc/ServingGrpcService.java
+++ b/serving/src/main/java/feast/serving/grpc/ServingGrpcService.java
@@ -77,14 +77,6 @@ public class ServingGrpcService extends ServingAPIImplBase {
       Request validRequest = checkTimestampRange(request);
       Response response = feast.queryFeatures(validRequest);
 
-      if (response.getEntitiesCount() < 1) {
-        responseObserver.onError(
-            new StatusRuntimeException(
-                Status.fromCode(NOT_FOUND)
-                    .withDescription("No value is found for the requested feature")));
-        return;
-      }
-
       innerSpan.log("calling onNext");
       responseObserver.onNext(response);
       innerSpan.log("calling onCompleted");


### PR DESCRIPTION
Avoid returning error to caller when the query is successful but returns empty result.