### PR TITLE
Change register to apply

### DIFF
--- a/cli/feast/cmd/jobs.go
+++ b/cli/feast/cmd/jobs.go
@@ -20,9 +20,8 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	"feast/cli/feast/pkg/parse"
-	"feast/cli/feast/pkg/printer"
-
+	"github.com/gojektech/feast/cli/feast/pkg/parse"
+	"github.com/gojektech/feast/cli/feast/pkg/printer"
 	"github.com/gojektech/feast/go-feast-proto/feast/core"
 
 	"github.com/spf13/cobra"

--- a/cli/feast/cmd/list.go
+++ b/cli/feast/cmd/list.go
@@ -17,12 +17,12 @@ package cmd
 import (
 	"context"
 	"errors"
-	"feast/cli/feast/pkg/util"
 	"fmt"
 	"os"
 	"strings"
 	"text/tabwriter"
 
+	"github.com/gojektech/feast/cli/feast/pkg/util"
 	"github.com/gojektech/feast/go-feast-proto/feast/core"
 
 	"github.com/golang/protobuf/ptypes/empty"

--- a/cli/feast/cmd/root.go
+++ b/cli/feast/cmd/root.go
@@ -15,7 +15,6 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -42,7 +41,6 @@ func init() {
 
 func handleErr(err error) {
 	if err != nil {
-		fmt.Println(err)
 		os.Exit(1)
 	}
 }

--- a/cli/feast/cmd/version.go
+++ b/cli/feast/cmd/version.go
@@ -20,7 +20,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "0.2.0"
+var version = "0.3.0"
 
 var versionCmd = &cobra.Command{
 	Use:   "version",

--- a/cli/feast/main.go
+++ b/cli/feast/main.go
@@ -14,7 +14,7 @@
 
 package main
 
-import "feast/cli/feast/cmd"
+import "github.com/gojektech/feast/cli/feast/cmd"
 
 func main() {
 	cmd.Execute()

--- a/cli/feast/pkg/printer/job.go
+++ b/cli/feast/pkg/printer/job.go
@@ -15,10 +15,10 @@
 package printer
 
 import (
-	"feast/cli/feast/pkg/util"
 	"fmt"
 	"strings"
 
+	"github.com/gojektech/feast/cli/feast/pkg/util"
 	"github.com/gojektech/feast/go-feast-proto/feast/core"
 )
 

--- a/core/src/main/java/feast/core/grpc/CoreServiceImpl.java
+++ b/core/src/main/java/feast/core/grpc/CoreServiceImpl.java
@@ -233,13 +233,13 @@ public class CoreServiceImpl extends CoreServiceImplBase {
    * error will be returned.
    */
   @Override
-  public void registerFeature(
-      FeatureSpec request, StreamObserver<RegisterFeatureResponse> responseObserver) {
+  public void applyFeature(
+      FeatureSpec request, StreamObserver<ApplyFeatureResponse> responseObserver) {
     try {
       validator.validateFeatureSpec(request);
       FeatureInfo feature = specService.applyFeature(request);
-      RegisterFeatureResponse response =
-          RegisterFeatureResponse.newBuilder().setFeatureId(feature.getId()).build();
+      ApplyFeatureResponse response =
+          ApplyFeatureResponse.newBuilder().setFeatureId(feature.getId()).build();
       responseObserver.onNext(response);
       responseObserver.onCompleted();
     } catch (RegistrationException e) {
@@ -257,14 +257,14 @@ public class CoreServiceImpl extends CoreServiceImplBase {
    * error will be returned.
    */
   @Override
-  public void registerFeatureGroup(
+  public void applyFeatureGroup(
       FeatureGroupSpecProto.FeatureGroupSpec request,
-      StreamObserver<RegisterFeatureGroupResponse> responseObserver) {
+      StreamObserver<ApplyFeatureGroupResponse> responseObserver) {
     try {
       validator.validateFeatureGroupSpec(request);
       FeatureGroupInfo featureGroup = specService.applyFeatureGroup(request);
-      RegisterFeatureGroupResponse response =
-          RegisterFeatureGroupResponse.newBuilder().setFeatureGroupId(featureGroup.getId()).build();
+      ApplyFeatureGroupResponse response =
+          ApplyFeatureGroupResponse.newBuilder().setFeatureGroupId(featureGroup.getId()).build();
       responseObserver.onNext(response);
       responseObserver.onCompleted();
     } catch (RegistrationException e) {
@@ -282,13 +282,13 @@ public class CoreServiceImpl extends CoreServiceImplBase {
    * be returned.
    */
   @Override
-  public void registerEntity(
-      EntitySpec request, StreamObserver<RegisterEntityResponse> responseObserver) {
+  public void applyEntity(
+      EntitySpec request, StreamObserver<ApplyEntityResponse> responseObserver) {
     try {
       validator.validateEntitySpec(request);
       EntityInfo entity = specService.applyEntity(request);
-      RegisterEntityResponse response =
-          RegisterEntityResponse.newBuilder().setEntityName(entity.getName()).build();
+      ApplyEntityResponse response =
+          ApplyEntityResponse.newBuilder().setEntityName(entity.getName()).build();
       responseObserver.onNext(response);
       responseObserver.onCompleted();
     } catch (RegistrationException e) {
@@ -306,13 +306,13 @@ public class CoreServiceImpl extends CoreServiceImplBase {
    * be returned.
    */
   @Override
-  public void registerStorage(
-      StorageSpec request, StreamObserver<RegisterStorageResponse> responseObserver) {
+  public void applyStorage(
+      StorageSpec request, StreamObserver<ApplyStorageResponse> responseObserver) {
     try {
       validator.validateStorageSpec(request);
       StorageInfo storage = specService.registerStorage(request);
-      RegisterStorageResponse response =
-          RegisterStorageResponse.newBuilder().setStorageId(storage.getId()).build();
+      ApplyStorageResponse response =
+          ApplyStorageResponse.newBuilder().setStorageId(storage.getId()).build();
       responseObserver.onNext(response);
       responseObserver.onCompleted();
     } catch (RegistrationException e) {

--- a/core/src/main/java/feast/core/grpc/CoreServiceImpl.java
+++ b/core/src/main/java/feast/core/grpc/CoreServiceImpl.java
@@ -237,16 +237,16 @@ public class CoreServiceImpl extends CoreServiceImplBase {
       FeatureSpec request, StreamObserver<RegisterFeatureResponse> responseObserver) {
     try {
       validator.validateFeatureSpec(request);
-      FeatureInfo feature = specService.registerFeature(request);
+      FeatureInfo feature = specService.applyFeature(request);
       RegisterFeatureResponse response =
           RegisterFeatureResponse.newBuilder().setFeatureId(feature.getId()).build();
       responseObserver.onNext(response);
       responseObserver.onCompleted();
     } catch (RegistrationException e) {
-      log.error("Error in registerFeature: {}", e);
+      log.error("Error in applyFeature: {}", e);
       responseObserver.onError(getRuntimeException(e));
     } catch (IllegalArgumentException e) {
-      log.error("Error in registerFeature: {}", e);
+      log.error("Error in applyFeature: {}", e);
       responseObserver.onError(getBadRequestException(e));
     }
   }
@@ -262,16 +262,16 @@ public class CoreServiceImpl extends CoreServiceImplBase {
       StreamObserver<RegisterFeatureGroupResponse> responseObserver) {
     try {
       validator.validateFeatureGroupSpec(request);
-      FeatureGroupInfo featureGroup = specService.registerFeatureGroup(request);
+      FeatureGroupInfo featureGroup = specService.applyFeatureGroup(request);
       RegisterFeatureGroupResponse response =
           RegisterFeatureGroupResponse.newBuilder().setFeatureGroupId(featureGroup.getId()).build();
       responseObserver.onNext(response);
       responseObserver.onCompleted();
     } catch (RegistrationException e) {
-      log.error("Error in registerFeatureGroup: {}", e);
+      log.error("Error in applyFeatureGroup: {}", e);
       responseObserver.onError(getRuntimeException(e));
     } catch (IllegalArgumentException e) {
-      log.error("Error in registerFeatureGroup: {}", e);
+      log.error("Error in applyFeatureGroup: {}", e);
       responseObserver.onError(getBadRequestException(e));
     }
   }
@@ -286,16 +286,16 @@ public class CoreServiceImpl extends CoreServiceImplBase {
       EntitySpec request, StreamObserver<RegisterEntityResponse> responseObserver) {
     try {
       validator.validateEntitySpec(request);
-      EntityInfo entity = specService.registerEntity(request);
+      EntityInfo entity = specService.applyEntity(request);
       RegisterEntityResponse response =
           RegisterEntityResponse.newBuilder().setEntityName(entity.getName()).build();
       responseObserver.onNext(response);
       responseObserver.onCompleted();
     } catch (RegistrationException e) {
-      log.error("Error in registerEntity: {}", e);
+      log.error("Error in applyEntity: {}", e);
       responseObserver.onError(getRuntimeException(e));
     } catch (IllegalArgumentException e) {
-      log.error("Error in registerEntity: {}", e);
+      log.error("Error in applyEntity: {}", e);
       responseObserver.onError(getBadRequestException(e));
     }
   }

--- a/core/src/main/java/feast/core/job/ScheduledJobMonitor.java
+++ b/core/src/main/java/feast/core/job/ScheduledJobMonitor.java
@@ -19,7 +19,9 @@ package feast.core.job;
 
 import com.google.common.base.Strings;
 import feast.core.dao.JobInfoRepository;
+import feast.core.log.Action;
 import feast.core.log.AuditLogger;
+import feast.core.log.Resource;
 import feast.core.model.JobInfo;
 import feast.core.model.JobStatus;
 import feast.core.model.Metrics;
@@ -74,9 +76,9 @@ public class ScheduledJobMonitor {
       JobStatus jobStatus = jobMonitor.getJobStatus(jobId);
       if (job.getStatus() != jobStatus) {
         AuditLogger.log(
-            "Jobs",
+            Resource.JOB,
             jobId,
-            "Status Update",
+            Action.STATUS_CHANGE,
             "Job status updated from %s to %s",
             job.getStatus(),
             jobStatus);

--- a/core/src/main/java/feast/core/log/Action.java
+++ b/core/src/main/java/feast/core/log/Action.java
@@ -1,0 +1,19 @@
+package feast.core.log;
+
+/**
+ * Actions taken for audit logging purposes
+ */
+public enum Action {
+  // Job-related actions
+  SUBMIT,
+  STATUS_CHANGE,
+  ABORT,
+
+  // Spec-related
+  UPDATE,
+  REGISTER,
+
+  // Storage-related
+  ADD,
+  SCHEMA_UPDATE,
+}

--- a/core/src/main/java/feast/core/log/AuditLogger.java
+++ b/core/src/main/java/feast/core/log/AuditLogger.java
@@ -39,12 +39,12 @@ public class AuditLogger {
    * @param detail additional detail. Supports string formatting.
    * @param args arguments to the detail string
    */
-  public static void log(String resource, String id, String action, String detail, Object... args) {
+  public static void log(Resource resource, String id, Action action, String detail, Object... args) {
     Map<String, String> map = new TreeMap<>();
     map.put("timestamp", new Date().toString());
-    map.put("resource", resource);
+    map.put("resource", resource.toString());
     map.put("id", id);
-    map.put("action", action);
+    map.put("action", action.toString());
     map.put("detail", Strings.lenientFormat(detail, args));
     ObjectMessage msg = new ObjectMessage(map);
 

--- a/core/src/main/java/feast/core/log/Resource.java
+++ b/core/src/main/java/feast/core/log/Resource.java
@@ -1,0 +1,12 @@
+package feast.core.log;
+
+/**
+ * Resources interacted with, for audit logging purposes
+ */
+public enum Resource {
+  FEATURE,
+  FEATURE_GROUP,
+  ENTITY,
+  STORAGE,
+  JOB
+}

--- a/core/src/main/java/feast/core/model/EntityInfo.java
+++ b/core/src/main/java/feast/core/model/EntityInfo.java
@@ -17,14 +17,13 @@
 
 package feast.core.model;
 
+import feast.core.UIServiceProto.UIServiceTypes.EntityDetail;
+import feast.specs.EntitySpecProto.EntitySpec;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
-import feast.core.UIServiceProto.UIServiceTypes.EntityDetail;
-import feast.specs.EntitySpecProto.EntitySpec;
 
 import javax.persistence.*;
-
 import java.util.List;
 
 import static feast.core.util.TypeConversion.convertTagStringToList;
@@ -66,25 +65,21 @@ public class EntityInfo extends AbstractTimestampEntity {
     this.tags = String.join(",", spec.getTagsList());
   }
 
-  /**
-   * Get the entity spec associated with this record.
-   */
+  /** Get the entity spec associated with this record. */
   public EntitySpec getEntitySpec() {
     return EntitySpec.newBuilder()
-            .setName(name)
-            .setDescription(description)
-            .addAllTags(convertTagStringToList(tags))
-            .build();
+        .setName(name)
+        .setDescription(description)
+        .addAllTags(convertTagStringToList(tags))
+        .build();
   }
 
-  /**
-   * Get the entity detail containing both spec and metadata, associated with this record.
-   */
+  /** Get the entity detail containing both spec and metadata, associated with this record. */
   public EntityDetail getEntityDetail() {
     return EntityDetail.newBuilder()
-            .setSpec(this.getEntitySpec())
-            .setLastUpdated(convertTimestamp(this.getLastUpdated()))
-            .build();
+        .setSpec(this.getEntitySpec())
+        .setLastUpdated(convertTimestamp(this.getLastUpdated()))
+        .build();
   }
 
   /**
@@ -96,5 +91,4 @@ public class EntityInfo extends AbstractTimestampEntity {
     this.description = update.getDescription();
     this.tags = String.join(",", update.getTagsList());
   }
-
 }

--- a/core/src/main/java/feast/core/model/EntityInfo.java
+++ b/core/src/main/java/feast/core/model/EntityInfo.java
@@ -86,4 +86,16 @@ public class EntityInfo extends AbstractTimestampEntity {
             .setLastUpdated(convertTimestamp(this.getLastUpdated()))
             .build();
   }
+
+  /**
+   * Checks if this is eq to the other given entity
+   *
+   * @param otherEntity
+   * @return boolean
+   */
+  public boolean eq(EntityInfo otherEntity) {
+    return otherEntity.getName().equals(this.getName()) &&
+            otherEntity.getDescription().equals(this.getDescription()) &&
+            otherEntity.getTags().equals(this.getTags());
+  }
 }

--- a/core/src/main/java/feast/core/model/EntityInfo.java
+++ b/core/src/main/java/feast/core/model/EntityInfo.java
@@ -88,14 +88,13 @@ public class EntityInfo extends AbstractTimestampEntity {
   }
 
   /**
-   * Checks if this is eq to the other given entity
+   * Updates the entity info with specifications from the incoming entity spec.
    *
-   * @param otherEntity
-   * @return boolean
+   * @param update new entity spec
    */
-  public boolean eq(EntityInfo otherEntity) {
-    return otherEntity.getName().equals(this.getName()) &&
-            otherEntity.getDescription().equals(this.getDescription()) &&
-            otherEntity.getTags().equals(this.getTags());
+  public void update(EntitySpec update) {
+    this.description = update.getDescription();
+    this.tags = String.join(",", update.getTagsList());
   }
+
 }

--- a/core/src/main/java/feast/core/model/FeatureGroupInfo.java
+++ b/core/src/main/java/feast/core/model/FeatureGroupInfo.java
@@ -17,14 +17,14 @@
 
 package feast.core.model;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.Setter;
 import feast.core.UIServiceProto.UIServiceTypes.FeatureGroupDetail;
 import feast.core.util.TypeConversion;
 import feast.specs.FeatureGroupSpecProto.FeatureGroupSpec;
 import feast.specs.FeatureSpecProto.DataStore;
 import feast.specs.FeatureSpecProto.DataStores;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
 
 import javax.persistence.*;
 
@@ -39,8 +39,7 @@ import javax.persistence.*;
 @Table(name = "feature_groups")
 public class FeatureGroupInfo extends AbstractTimestampEntity {
 
-  @Id
-  private String id;
+  @Id private String id;
 
   @Column(name = "tags")
   private String tags;
@@ -63,43 +62,40 @@ public class FeatureGroupInfo extends AbstractTimestampEntity {
     super();
   }
 
-  public FeatureGroupInfo(FeatureGroupSpec spec,
-                          StorageInfo servingStore,
-                          StorageInfo warehouseStore) {
+  public FeatureGroupInfo(
+      FeatureGroupSpec spec, StorageInfo servingStore, StorageInfo warehouseStore) {
     this.id = spec.getId();
     this.tags = String.join(",", spec.getTagsList());
     this.servingStore = servingStore;
     this.warehouseStore = warehouseStore;
     this.servingStoreOpts =
-            TypeConversion.convertMapToJsonString(spec.getDataStores().getServing().getOptionsMap());
+        TypeConversion.convertMapToJsonString(spec.getDataStores().getServing().getOptionsMap());
     this.warehouseStoreOpts =
-            TypeConversion.convertMapToJsonString(spec.getDataStores().getWarehouse().getOptionsMap());
+        TypeConversion.convertMapToJsonString(spec.getDataStores().getWarehouse().getOptionsMap());
   }
 
-  /**
-   * Get the feature group spec associated with this record.
-   */
+  /** Get the feature group spec associated with this record. */
   public FeatureGroupSpec getFeatureGroupSpec() {
     DataStore servingDataStore =
-            DataStore.newBuilder()
-                    .setId(servingStore.getId())
-                    .putAllOptions(TypeConversion.convertJsonStringToMap(servingStoreOpts))
-                    .build();
-    DataStore warehouseDataStore =
-            DataStore.newBuilder()
-                    .setId(warehouseStore.getId())
-                    .putAllOptions(TypeConversion.convertJsonStringToMap(warehouseStoreOpts))
-                    .build();
-    DataStores dataStores =
-            DataStores.newBuilder()
-                    .setWarehouse(warehouseDataStore)
-                    .setServing(servingDataStore)
-                    .build();
-    return FeatureGroupSpec.newBuilder()
-            .setId(id)
-            .addAllTags(TypeConversion.convertTagStringToList(tags))
-            .setDataStores(dataStores)
+        DataStore.newBuilder()
+            .setId(servingStore.getId())
+            .putAllOptions(TypeConversion.convertJsonStringToMap(servingStoreOpts))
             .build();
+    DataStore warehouseDataStore =
+        DataStore.newBuilder()
+            .setId(warehouseStore.getId())
+            .putAllOptions(TypeConversion.convertJsonStringToMap(warehouseStoreOpts))
+            .build();
+    DataStores dataStores =
+        DataStores.newBuilder()
+            .setWarehouse(warehouseDataStore)
+            .setServing(servingDataStore)
+            .build();
+    return FeatureGroupSpec.newBuilder()
+        .setId(id)
+        .addAllTags(TypeConversion.convertTagStringToList(tags))
+        .setDataStores(dataStores)
+        .build();
   }
 
   /**
@@ -107,24 +103,34 @@ public class FeatureGroupInfo extends AbstractTimestampEntity {
    */
   public FeatureGroupDetail getFeatureGroupDetail() {
     return FeatureGroupDetail.newBuilder()
-            .setSpec(this.getFeatureGroupSpec())
-            .setLastUpdated(TypeConversion.convertTimestamp(this.getLastUpdated()))
-            .build();
+        .setSpec(this.getFeatureGroupSpec())
+        .setLastUpdated(TypeConversion.convertTimestamp(this.getLastUpdated()))
+        .build();
   }
 
-  /**
-   * Checks if this is eq to the other given feature group
-   *
-   * @param otherFeatureGroup
-   * @return boolean
-   */
-  public boolean eq(FeatureGroupInfo otherFeatureGroup) {
-    return otherFeatureGroup.getId() == this.id &&
-            otherFeatureGroup.getTags() == this.getTags() &&
-            otherFeatureGroup.getServingStoreOpts() == this.servingStoreOpts &&
-            getStorageId(otherFeatureGroup.getServingStore()) == getStorageId(this.getServingStore()) &&
-            otherFeatureGroup.getWarehouseStoreOpts() == this.warehouseStoreOpts &&
-            getStorageId(otherFeatureGroup.getWarehouseStore()) == getStorageId(this.getWarehouseStore());
+  public void update(FeatureGroupSpec update) throws IllegalArgumentException {
+    if (!isLegalUpdate(update)) {
+      throw new IllegalArgumentException(
+          "Feature group already exists. Update only allowed for fields: [tags]");
+    }
+    this.tags = String.join(",", update.getTagsList());
+  }
+
+  private boolean isLegalUpdate(FeatureGroupSpec update) {
+    DataStore updatedWarehouseStore =
+        update.getDataStores().hasWarehouse() ? update.getDataStores().getWarehouse() : null;
+    DataStore updatedServingStore =
+        update.getDataStores().hasServing() ? update.getDataStores().getServing() : null;
+    return isStoreEqual(this.warehouseStore, this.warehouseStoreOpts, updatedWarehouseStore)
+        && isStoreEqual(this.servingStore, this.servingStoreOpts, updatedServingStore);
+  }
+
+  private boolean isStoreEqual(StorageInfo oldStore, String oldStoreOpts, DataStore newStore) {
+    return getStorageId(oldStore).equals(newStore == null ? "" : newStore.getId())
+        && oldStoreOpts.equals(
+            newStore == null
+                ? ""
+                : TypeConversion.convertMapToJsonString(newStore.getOptionsMap()));
   }
 
   private String getStorageId(StorageInfo storage) {

--- a/core/src/main/java/feast/core/model/FeatureGroupInfo.java
+++ b/core/src/main/java/feast/core/model/FeatureGroupInfo.java
@@ -111,4 +111,23 @@ public class FeatureGroupInfo extends AbstractTimestampEntity {
             .setLastUpdated(TypeConversion.convertTimestamp(this.getLastUpdated()))
             .build();
   }
+
+  /**
+   * Checks if this is eq to the other given feature group
+   *
+   * @param otherFeatureGroup
+   * @return boolean
+   */
+  public boolean eq(FeatureGroupInfo otherFeatureGroup) {
+    return otherFeatureGroup.getId() == this.id &&
+            otherFeatureGroup.getTags() == this.getTags() &&
+            otherFeatureGroup.getServingStoreOpts() == this.servingStoreOpts &&
+            getStorageId(otherFeatureGroup.getServingStore()) == getStorageId(this.getServingStore()) &&
+            otherFeatureGroup.getWarehouseStoreOpts() == this.warehouseStoreOpts &&
+            getStorageId(otherFeatureGroup.getWarehouseStore()) == getStorageId(this.getWarehouseStore());
+  }
+
+  private String getStorageId(StorageInfo storage) {
+    return storage == null ? "" : storage.getId();
+  }
 }

--- a/core/src/main/java/feast/core/model/FeatureGroupInfo.java
+++ b/core/src/main/java/feast/core/model/FeatureGroupInfo.java
@@ -117,23 +117,7 @@ public class FeatureGroupInfo extends AbstractTimestampEntity {
   }
 
   private boolean isLegalUpdate(FeatureGroupSpec update) {
-    DataStore updatedWarehouseStore =
-        update.getDataStores().hasWarehouse() ? update.getDataStores().getWarehouse() : null;
-    DataStore updatedServingStore =
-        update.getDataStores().hasServing() ? update.getDataStores().getServing() : null;
-    return isStoreEqual(this.warehouseStore, this.warehouseStoreOpts, updatedWarehouseStore)
-        && isStoreEqual(this.servingStore, this.servingStoreOpts, updatedServingStore);
-  }
-
-  private boolean isStoreEqual(StorageInfo oldStore, String oldStoreOpts, DataStore newStore) {
-    return getStorageId(oldStore).equals(newStore == null ? "" : newStore.getId())
-        && oldStoreOpts.equals(
-            newStore == null
-                ? ""
-                : TypeConversion.convertMapToJsonString(newStore.getOptionsMap()));
-  }
-
-  private String getStorageId(StorageInfo storage) {
-    return storage == null ? "" : storage.getId();
+    FeatureGroupSpec spec = this.getFeatureGroupSpec();
+    return spec.getDataStores().equals(update.getDataStores());
   }
 }

--- a/core/src/main/java/feast/core/model/FeatureInfo.java
+++ b/core/src/main/java/feast/core/model/FeatureInfo.java
@@ -273,33 +273,13 @@ public class FeatureInfo extends AbstractTimestampEntity {
   }
 
   private boolean isLegalUpdate(FeatureSpec update) {
-    DataStore updatedWarehouseStore =
-        update.getDataStores().hasWarehouse() ? update.getDataStores().getWarehouse() : null;
-    DataStore updatedServingStore =
-        update.getDataStores().hasServing() ? update.getDataStores().getServing() : null;
-    return update.getName().equals(this.name)
-        && update.getEntity().equals(this.entity.getName())
-        && update.getGranularityValue() == this.granularity.getNumber()
-        && update.getValueTypeValue() == this.valueType.getNumber()
-        && update.getGroup().equals(getFeatureGroupId(this.featureGroup))
-        && TypeConversion.convertMapToJsonString(update.getOptionsMap()).equals(this.options)
-        && isStoreEqual(this.warehouseStore, this.warehouseStoreOpts, updatedWarehouseStore)
-        && isStoreEqual(this.servingStore, this.servingStoreOpts, updatedServingStore);
-  }
-
-  private boolean isStoreEqual(StorageInfo oldStore, String oldStoreOpts, DataStore newStore) {
-    return getStorageId(oldStore).equals(newStore == null ? "" : newStore.getId())
-        && oldStoreOpts.equals(
-            newStore == null
-                ? ""
-                : TypeConversion.convertMapToJsonString(newStore.getOptionsMap()));
-  }
-
-  private String getFeatureGroupId(FeatureGroupInfo featureGroupInfo) {
-    return featureGroupInfo == null ? "" : featureGroupInfo.getId();
-  }
-
-  private String getStorageId(StorageInfo storage) {
-    return storage == null ? "" : storage.getId();
+    FeatureSpec spec = this.getFeatureSpec();
+    return spec.getName().equals(update.getName())
+        && spec.getEntity().equals(update.getEntity())
+        && spec.getGranularity().equals(update.getGranularity())
+        && spec.getValueType().equals(update.getValueType())
+        && spec.getGroup().equals(update.getGroup())
+        && spec.getOptionsMap().equals(update.getOptionsMap())
+        && spec.getDataStores().equals(update.getDataStores());
   }
 }

--- a/core/src/main/java/feast/core/model/FeatureInfo.java
+++ b/core/src/main/java/feast/core/model/FeatureInfo.java
@@ -256,4 +256,34 @@ public class FeatureInfo extends AbstractTimestampEntity {
         "https://bigquery.cloud.google.com/table/%s:%s.%s_%s_view",
         projectId, dataset, entity.getName(), granularity.toString().toLowerCase());
   }
+
+  /**
+   * Checks if this is eq to the other given feature
+   *
+   * @param otherFeature
+   * @return boolean
+   */
+  public boolean eq(FeatureInfo otherFeature) {
+    return otherFeature.getId() == this.id &&
+            otherFeature.getEntity().getName() == this.entity.getName() &&
+            otherFeature.getOwner() == this.owner &&
+            otherFeature.getUri() == this.uri &&
+            otherFeature.getDescription() == this.description &&
+            otherFeature.getGranularity() == this.granularity &&
+            otherFeature.getValueType() == this.valueType &&
+            otherFeature.getTags() == this.tags &&
+            otherFeature.getOptions() == this.options &&
+            getFeatureGroupId(otherFeature.getFeatureGroup()) == getFeatureGroupId(this.getFeatureGroup()) &&
+            otherFeature.getServingStoreOpts() == this.servingStoreOpts &&
+            getStorageId(otherFeature.getServingStore()) == getStorageId(this.getServingStore()) &&
+            otherFeature.getWarehouseStoreOpts() == this.warehouseStoreOpts &&
+            getStorageId(otherFeature.getWarehouseStore()) == getStorageId(this.getWarehouseStore());
+  }
+
+  private String getFeatureGroupId(FeatureGroupInfo featureGroupInfo) {
+    return featureGroupInfo == null ? "" : featureGroupInfo.getId();
+  }
+  private String getStorageId(StorageInfo storage) {
+    return storage == null ? "" : storage.getId();
+  }
 }

--- a/core/src/main/java/feast/core/model/StorageInfo.java
+++ b/core/src/main/java/feast/core/model/StorageInfo.java
@@ -80,16 +80,4 @@ public class StorageInfo extends AbstractTimestampEntity {
             .setLastUpdated(convertTimestamp(this.getLastUpdated()))
             .build();
   }
-
-  /**
-   * Checks if this is eq to the other given storage
-   *
-   * @param otherStorage
-   * @return boolean
-   */
-  public boolean eq(StorageInfo otherStorage) {
-    return otherStorage.getId().equals(this.id) &&
-            otherStorage.getType().equals(this.type) &&
-            otherStorage.getOptions().equals(this.options);
-  }
 }

--- a/core/src/main/java/feast/core/model/StorageInfo.java
+++ b/core/src/main/java/feast/core/model/StorageInfo.java
@@ -17,11 +17,11 @@
 
 package feast.core.model;
 
+import feast.core.UIServiceProto.UIServiceTypes.StorageDetail;
+import feast.specs.StorageSpecProto.StorageSpec;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
-import feast.core.UIServiceProto.UIServiceTypes.StorageDetail;
-import feast.specs.StorageSpecProto.StorageSpec;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -79,5 +79,17 @@ public class StorageInfo extends AbstractTimestampEntity {
             .setSpec(this.getStorageSpec())
             .setLastUpdated(convertTimestamp(this.getLastUpdated()))
             .build();
+  }
+
+  /**
+   * Checks if this is eq to the other given storage
+   *
+   * @param otherStorage
+   * @return boolean
+   */
+  public boolean eq(StorageInfo otherStorage) {
+    return otherStorage.getId().equals(this.id) &&
+            otherStorage.getType().equals(this.type) &&
+            otherStorage.getOptions().equals(this.options);
   }
 }

--- a/core/src/main/java/feast/core/service/JobManagementService.java
+++ b/core/src/main/java/feast/core/service/JobManagementService.java
@@ -23,7 +23,9 @@ import feast.core.dao.JobInfoRepository;
 import feast.core.dao.MetricsRepository;
 import feast.core.exception.RetrievalException;
 import feast.core.job.JobManager;
+import feast.core.log.Action;
 import feast.core.log.AuditLogger;
+import feast.core.log.Resource;
 import feast.core.model.JobInfo;
 import feast.core.model.JobStatus;
 import feast.core.model.Metrics;
@@ -54,6 +56,7 @@ public class JobManagementService {
 
   /**
    * Lists all jobs registered to the db.
+   *
    * @return list of JobDetails
    */
   @Transactional
@@ -64,6 +67,7 @@ public class JobManagementService {
 
   /**
    * Gets information regarding a single job.
+   *
    * @param id feast-internal job id
    * @return JobDetail for that job
    */
@@ -82,10 +86,10 @@ public class JobManagementService {
   }
 
   /**
-   * Drain the given job. If this is successful, the job will start the draining process.
-   * When the draining process is complete, the job will be cleaned up and removed.
+   * Drain the given job. If this is successful, the job will start the draining process. When the
+   * draining process is complete, the job will be cleaned up and removed.
    *
-   * Batch jobs will be cancelled, as draining these jobs is not supported by beam.
+   * <p>Batch jobs will be cancelled, as draining these jobs is not supported by beam.
    *
    * @param id feast-internal id of a job
    */
@@ -101,7 +105,7 @@ public class JobManagementService {
     jobManager.abortJob(job.getExtId());
     job.setStatus(JobStatus.ABORTING);
 
-    AuditLogger.log("Jobs", id, "Aborting", "Triggering draining of job");
+    AuditLogger.log(Resource.JOB, id, Action.ABORT, "Triggering draining of job");
     jobInfoRepository.saveAndFlush(job);
   }
 }

--- a/core/src/main/java/feast/core/storage/BigQueryStorageManager.java
+++ b/core/src/main/java/feast/core/storage/BigQueryStorageManager.java
@@ -21,7 +21,9 @@ import com.google.cloud.bigquery.*;
 import com.google.cloud.bigquery.TimePartitioning.Type;
 import com.google.common.base.Strings;
 import com.google.protobuf.util.JsonFormat;
+import feast.core.log.Action;
 import feast.core.log.AuditLogger;
+import feast.core.log.Resource;
 import feast.specs.FeatureSpecProto.FeatureSpec;
 import feast.types.ValueProto.ValueType;
 import feast.types.ValueProto.ValueType.Enum;
@@ -138,11 +140,11 @@ public class BigQueryStorageManager implements StorageManager {
                         && !f.equals(FIELD_EVENT_TIMESTAMP))
             .collect(Collectors.toList()));
     AuditLogger.log(
-            "Storage",
-            this.id,
-            "Schema Updated",
-            "Bigquery schema updated for feature %s",
-            featureSpec.getId());
+        Resource.STORAGE,
+        this.id,
+        Action.SCHEMA_UPDATE,
+        "Bigquery schema updated for feature %s",
+        featureSpec.getId());
   }
 
   private void checkTableCreation(Table table, FeatureSpec featureSpec) {

--- a/core/src/main/java/feast/core/storage/BigTableStorageManager.java
+++ b/core/src/main/java/feast/core/storage/BigTableStorageManager.java
@@ -18,7 +18,9 @@
 package feast.core.storage;
 
 import com.google.common.base.Strings;
+import feast.core.log.Action;
 import feast.core.log.AuditLogger;
+import feast.core.log.Resource;
 import feast.specs.FeatureSpecProto.FeatureSpec;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.hadoop.hbase.TableName;
@@ -81,11 +83,11 @@ public class BigTableStorageManager implements StorageManager {
         log.info("Created new column family: {} for entity: {}", columnFamily, entityName);
       }
       AuditLogger.log(
-              "Storage",
-              this.id,
-              "Schema Updated",
-              "Bigtable schema updated for feature %s",
-              featureSpec.getId());
+          Resource.STORAGE,
+          this.id,
+          Action.SCHEMA_UPDATE,
+          "Bigtable schema updated for feature %s",
+          featureSpec.getId());
     } catch (IOException e) {
       log.error("Unable to create table in BigTable: {}", e);
       throw new StorageInitializationException("Unable to create table in BigTable", e);

--- a/core/src/main/java/feast/core/storage/PostgresStorageManager.java
+++ b/core/src/main/java/feast/core/storage/PostgresStorageManager.java
@@ -17,7 +17,9 @@
 
 package feast.core.storage;
 
+import feast.core.log.Action;
 import feast.core.log.AuditLogger;
+import feast.core.log.Resource;
 import org.jdbi.v3.core.Jdbi;
 import feast.specs.FeatureSpecProto.FeatureSpec;
 import feast.types.ValueProto.ValueType.Enum;
@@ -76,11 +78,11 @@ public class PostgresStorageManager implements StorageManager {
               return null;
             });
     AuditLogger.log(
-            "Storage",
-            this.id,
-            "Schema Updated",
-            "Postgres schema updated for feature %s",
-            featureSpec.getId());
+        Resource.STORAGE,
+        this.id,
+        Action.SCHEMA_UPDATE,
+        "Postgres schema updated for feature %s",
+        featureSpec.getId());
   }
 
   private String createFieldType(FeatureSpec featureSpec) {

--- a/core/src/test/java/feast/core/model/EntityInfoTest.java
+++ b/core/src/test/java/feast/core/model/EntityInfoTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import feast.core.UIServiceProto.UIServiceTypes.EntityDetail;
 import feast.specs.EntitySpecProto.EntitySpec;
 
+import java.time.Instant;
 import java.util.Date;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -65,5 +66,14 @@ public class EntityInfoTest {
     EntityDetail expected =
             EntityDetail.newBuilder().setSpec(entitySpec).setLastUpdated(ts).build();
     assertThat(entityInfo.getEntityDetail(), equalTo(expected));
+  }
+
+  @Test
+  public void shouldBeEqualToEntityFromSameSpecs() {
+    EntityInfo entity1 = new EntityInfo(entitySpec);
+    entity1.setCreated(Date.from(Instant.ofEpochSecond(1)));
+    EntityInfo entity2 = new EntityInfo(entitySpec);
+    entity1.setCreated(Date.from(Instant.ofEpochSecond(2)));
+    assertThat(entity1.eq(entity2), equalTo(true));
   }
 }

--- a/core/src/test/java/feast/core/model/EntityInfoTest.java
+++ b/core/src/test/java/feast/core/model/EntityInfoTest.java
@@ -17,6 +17,7 @@
 
 package feast.core.model;
 
+import com.google.api.client.util.Lists;
 import com.google.protobuf.Timestamp;
 import org.junit.Before;
 import org.junit.Test;
@@ -69,11 +70,11 @@ public class EntityInfoTest {
   }
 
   @Test
-  public void shouldBeEqualToEntityFromSameSpecs() {
-    EntityInfo entity1 = new EntityInfo(entitySpec);
-    entity1.setCreated(Date.from(Instant.ofEpochSecond(1)));
-    EntityInfo entity2 = new EntityInfo(entitySpec);
-    entity1.setCreated(Date.from(Instant.ofEpochSecond(2)));
-    assertThat(entity1.eq(entity2), equalTo(true));
+  public void shouldUpdateTagAndDescription() {
+    EntityInfo entityInfo = new EntityInfo("entity", "test entity", "tag1,tag2", Lists.newArrayList(), false);
+    EntitySpec update = EntitySpec.newBuilder().setName("entity").setDescription("overwrite").addTags("newtag").build();
+    EntityInfo expected = new EntityInfo("entity", "overwrite", "newtag", Lists.newArrayList(), false);
+    entityInfo.update(update);
+    assertThat(entityInfo, equalTo(expected));
   }
 }

--- a/core/src/test/java/feast/core/model/FeatureGroupInfoTest.java
+++ b/core/src/test/java/feast/core/model/FeatureGroupInfoTest.java
@@ -25,6 +25,7 @@ import feast.specs.FeatureGroupSpecProto.FeatureGroupSpec;
 import feast.specs.FeatureSpecProto.DataStore;
 import feast.specs.FeatureSpecProto.DataStores;
 
+import java.time.Instant;
 import java.util.Date;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -83,5 +84,14 @@ public class FeatureGroupInfoTest {
     FeatureGroupDetail expected =
             FeatureGroupDetail.newBuilder().setSpec(featureGroupSpec).setLastUpdated(ts).build();
     assertThat(featureGroupInfo.getFeatureGroupDetail(), equalTo(expected));
+  }
+
+  @Test
+  public void shouldBeEqualToFeatureGroupFromSameSpecs() {
+    FeatureGroupInfo featureGroup1 = new FeatureGroupInfo(featureGroupSpec, servingStorage, warehouseStorage);
+    featureGroup1.setCreated(Date.from(Instant.ofEpochSecond(1)));
+    FeatureGroupInfo featureGroup2 = new FeatureGroupInfo(featureGroupSpec, servingStorage, warehouseStorage);
+    featureGroup2.setCreated(Date.from(Instant.ofEpochSecond(2)));
+    assertThat(featureGroup1.eq(featureGroup2), equalTo(true));
   }
 }

--- a/core/src/test/java/feast/core/model/FeatureGroupInfoTest.java
+++ b/core/src/test/java/feast/core/model/FeatureGroupInfoTest.java
@@ -18,14 +18,16 @@
 package feast.core.model;
 
 import com.google.protobuf.Timestamp;
-import org.junit.Before;
-import org.junit.Test;
 import feast.core.UIServiceProto.UIServiceTypes.FeatureGroupDetail;
+import feast.core.exception.RetrievalException;
 import feast.specs.FeatureGroupSpecProto.FeatureGroupSpec;
 import feast.specs.FeatureSpecProto.DataStore;
 import feast.specs.FeatureSpecProto.DataStores;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
-import java.time.Instant;
 import java.util.Date;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -36,6 +38,8 @@ public class FeatureGroupInfoTest {
   private FeatureGroupSpec featureGroupSpec;
   private StorageInfo servingStorage;
   private StorageInfo warehouseStorage;
+
+  @Rule public final ExpectedException exception = ExpectedException.none();
 
   @Before
   public void setUp() {
@@ -56,15 +60,15 @@ public class FeatureGroupInfoTest {
     DataStore servingStore = DataStore.newBuilder().setId("REDIS1").build();
     DataStore warehouseStore = DataStore.newBuilder().setId("REDIS2").build();
     DataStores dataStores =
-            DataStores.newBuilder().setServing(servingStore).setWarehouse(warehouseStore).build();
+        DataStores.newBuilder().setServing(servingStore).setWarehouse(warehouseStore).build();
 
     featureGroupSpec =
-            FeatureGroupSpec.newBuilder()
-                    .setId("test")
-                    .addTags("tag1")
-                    .addTags("tag2")
-                    .setDataStores(dataStores)
-                    .build();
+        FeatureGroupSpec.newBuilder()
+            .setId("test")
+            .addTags("tag1")
+            .addTags("tag2")
+            .setDataStores(dataStores)
+            .build();
   }
 
   @Test
@@ -74,7 +78,9 @@ public class FeatureGroupInfoTest {
 
   @Test
   public void shouldCorrectlyInitialiseFromGivenSpec() {
-    assertThat(new FeatureGroupInfo(featureGroupSpec, servingStorage, warehouseStorage), equalTo(featureGroupInfo));
+    assertThat(
+        new FeatureGroupInfo(featureGroupSpec, servingStorage, warehouseStorage),
+        equalTo(featureGroupInfo));
   }
 
   @Test
@@ -82,16 +88,44 @@ public class FeatureGroupInfoTest {
     featureGroupInfo.setLastUpdated(new Date(1000));
     Timestamp ts = Timestamp.newBuilder().setSeconds(1).build();
     FeatureGroupDetail expected =
-            FeatureGroupDetail.newBuilder().setSpec(featureGroupSpec).setLastUpdated(ts).build();
+        FeatureGroupDetail.newBuilder().setSpec(featureGroupSpec).setLastUpdated(ts).build();
     assertThat(featureGroupInfo.getFeatureGroupDetail(), equalTo(expected));
   }
 
   @Test
-  public void shouldBeEqualToFeatureGroupFromSameSpecs() {
-    FeatureGroupInfo featureGroup1 = new FeatureGroupInfo(featureGroupSpec, servingStorage, warehouseStorage);
-    featureGroup1.setCreated(Date.from(Instant.ofEpochSecond(1)));
-    FeatureGroupInfo featureGroup2 = new FeatureGroupInfo(featureGroupSpec, servingStorage, warehouseStorage);
-    featureGroup2.setCreated(Date.from(Instant.ofEpochSecond(2)));
-    assertThat(featureGroup1.eq(featureGroup2), equalTo(true));
+  public void shouldUpdateTags() {
+    DataStore servingStore = DataStore.newBuilder().setId("REDIS1").build();
+    DataStore warehouseStore = DataStore.newBuilder().setId("REDIS2").build();
+    DataStores dataStores =
+        DataStores.newBuilder().setServing(servingStore).setWarehouse(warehouseStore).build();
+
+    FeatureGroupSpec update =
+        FeatureGroupSpec.newBuilder()
+            .setId("test")
+            .addTags("newtag")
+            .setDataStores(dataStores)
+            .build();
+    featureGroupInfo.update(update);
+
+    FeatureGroupInfo expected = new FeatureGroupInfo(update, servingStorage, warehouseStorage);
+    assertThat(featureGroupInfo, equalTo(expected));
+  }
+
+  @Test
+  public void shouldThrowErrorIfDatastoresChanged() {
+    DataStore servingStore = DataStore.newBuilder().setId("REDIS3").build();
+    DataStore warehouseStore = DataStore.newBuilder().setId("REDIS2").build();
+    DataStores dataStores =
+            DataStores.newBuilder().setServing(servingStore).setWarehouse(warehouseStore).build();
+
+    FeatureGroupSpec update =
+            FeatureGroupSpec.newBuilder()
+                    .setId("test")
+                    .addTags("newtag")
+                    .setDataStores(dataStores)
+                    .build();
+    exception.expect(IllegalArgumentException.class);
+    exception.expectMessage("Feature group already exists. Update only allowed for fields: [tags]");
+    featureGroupInfo.update(update);
   }
 }

--- a/core/src/test/java/feast/core/model/FeatureInfoTest.java
+++ b/core/src/test/java/feast/core/model/FeatureInfoTest.java
@@ -232,4 +232,25 @@ public class FeatureInfoTest {
     exception.expectMessage( "Feature already exists. Update only allowed for fields: [owner, description, uri, tags]");
     featureInfo.update(update);
   }
+
+
+  @Test
+  public void shouldThrowExceptionIfImmutableFieldsChangedToNull() {
+    FeatureSpec update =
+            FeatureSpec.newBuilder()
+                    .setId("entity.NONE.name")
+                    .setName("name")
+                    .setOwner("owner2")
+                    .setDescription("overwrite")
+                    .setEntity("entity")
+                    .setUri("new_uri")
+                    .setGranularity(Granularity.Enum.NONE)
+                    .setValueType(ValueType.Enum.BYTES)
+                    .addTags("new_tag")
+                    .build();
+
+    exception.expect(IllegalArgumentException.class);
+    exception.expectMessage( "Feature already exists. Update only allowed for fields: [owner, description, uri, tags]");
+    featureInfo.update(update);
+  }
 }

--- a/core/src/test/java/feast/core/model/FeatureInfoTest.java
+++ b/core/src/test/java/feast/core/model/FeatureInfoTest.java
@@ -27,6 +27,7 @@ import feast.specs.FeatureSpecProto.DataStores;
 import feast.specs.FeatureSpecProto.FeatureSpec;
 import feast.types.ValueProto.ValueType;
 
+import java.time.Instant;
 import java.util.Date;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -167,5 +168,14 @@ public class FeatureInfoTest {
                     .build();
     FeatureInfo resolved = featureInfo.resolve();
     assertThat(resolved.getFeatureSpec(), equalTo(expected));
+  }
+
+  @Test
+  public void shouldBeEqualToFeatureFromSameSpecs() {
+    FeatureInfo feature1 = new FeatureInfo(featureSpec, entityInfo, servingStorage, warehouseStorage, null);
+    feature1.setCreated(Date.from(Instant.ofEpochSecond(1)));
+    FeatureInfo feature2 = new FeatureInfo(featureSpec, entityInfo, servingStorage, warehouseStorage, null);
+    feature2.setCreated(Date.from(Instant.ofEpochSecond(2)));
+    assertThat(feature1.eq(feature2), equalTo(true));
   }
 }

--- a/core/src/test/java/feast/core/model/StorageInfoTest.java
+++ b/core/src/test/java/feast/core/model/StorageInfoTest.java
@@ -23,6 +23,7 @@ import feast.specs.StorageSpecProto.StorageSpec;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.time.Instant;
 import java.util.Date;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -64,5 +65,14 @@ public class StorageInfoTest {
     StorageDetail expected =
         StorageDetail.newBuilder().setSpec(storageSpec).setLastUpdated(ts).build();
     assertThat(storageInfo.getStorageDetail(), equalTo(expected));
+  }
+
+  @Test
+  public void shouldBeEqualToStorageFromSameSpecs() {
+    StorageInfo storage1 = new StorageInfo(storageSpec);
+    storage1.setCreated(Date.from(Instant.ofEpochSecond(1)));
+    StorageInfo storage2 = new StorageInfo(storageSpec);
+    storage2.setCreated(Date.from(Instant.ofEpochSecond(2)));
+    assertThat(storage1.eq(storage2), equalTo(true));
   }
 }

--- a/core/src/test/java/feast/core/model/StorageInfoTest.java
+++ b/core/src/test/java/feast/core/model/StorageInfoTest.java
@@ -66,13 +66,4 @@ public class StorageInfoTest {
         StorageDetail.newBuilder().setSpec(storageSpec).setLastUpdated(ts).build();
     assertThat(storageInfo.getStorageDetail(), equalTo(expected));
   }
-
-  @Test
-  public void shouldBeEqualToStorageFromSameSpecs() {
-    StorageInfo storage1 = new StorageInfo(storageSpec);
-    storage1.setCreated(Date.from(Instant.ofEpochSecond(1)));
-    StorageInfo storage2 = new StorageInfo(storageSpec);
-    storage2.setCreated(Date.from(Instant.ofEpochSecond(2)));
-    assertThat(storage1.eq(storage2), equalTo(true));
-  }
 }

--- a/core/src/test/java/feast/core/service/SpecServiceTest.java
+++ b/core/src/test/java/feast/core/service/SpecServiceTest.java
@@ -326,7 +326,7 @@ public class SpecServiceTest {
             storageInfoRepository,
             featureGroupInfoRepository,
             schemaManager);
-    FeatureInfo actual = specService.registerFeature(spec);
+    FeatureInfo actual = specService.applyFeature(spec);
     verify(schemaManager).registerFeature(resolvedSpecCaptor.capture());
 
     assertThat(resolvedSpecCaptor.getValue(), equalTo(resolvedSpec));
@@ -363,7 +363,7 @@ public class SpecServiceTest {
             storageInfoRepository,
             featureGroupInfoRepository,
             schemaManager);
-    FeatureGroupInfo actual = specService.registerFeatureGroup(spec);
+    FeatureGroupInfo actual = specService.applyFeatureGroup(spec);
     assertThat(actual, equalTo(expectedFeatureGroupInfo));
   }
 
@@ -395,7 +395,7 @@ public class SpecServiceTest {
             schemaManager);
 
     exception.expect(RegistrationException.class);
-    specService.registerFeatureGroup(spec);
+    specService.applyFeatureGroup(spec);
   }
 
   @Test
@@ -415,7 +415,7 @@ public class SpecServiceTest {
             storageInfoRepository,
             featureGroupInfoRepository,
             schemaManager);
-    EntityInfo actual = specService.registerEntity(spec);
+    EntityInfo actual = specService.applyEntity(spec);
     assertThat(actual, equalTo(entityInfo));
   }
 
@@ -434,4 +434,5 @@ public class SpecServiceTest {
     StorageInfo actual = specService.registerStorage(spec);
     assertThat(actual, equalTo(storageInfo));
   }
+
 }

--- a/go-feast-proto/feast/core/CoreService.pb.go
+++ b/go-feast-proto/feast/core/CoreService.pb.go
@@ -35,7 +35,7 @@ func (m *CoreServiceTypes) Reset()         { *m = CoreServiceTypes{} }
 func (m *CoreServiceTypes) String() string { return proto.CompactTextString(m) }
 func (*CoreServiceTypes) ProtoMessage()    {}
 func (*CoreServiceTypes) Descriptor() ([]byte, []int) {
-	return fileDescriptor_CoreService_aeabad36f2a7449f, []int{0}
+	return fileDescriptor_CoreService_ab3e56c9944743b5, []int{0}
 }
 func (m *CoreServiceTypes) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CoreServiceTypes.Unmarshal(m, b)
@@ -66,7 +66,7 @@ func (m *CoreServiceTypes_GetEntitiesRequest) Reset()         { *m = CoreService
 func (m *CoreServiceTypes_GetEntitiesRequest) String() string { return proto.CompactTextString(m) }
 func (*CoreServiceTypes_GetEntitiesRequest) ProtoMessage()    {}
 func (*CoreServiceTypes_GetEntitiesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_CoreService_aeabad36f2a7449f, []int{0, 0}
+	return fileDescriptor_CoreService_ab3e56c9944743b5, []int{0, 0}
 }
 func (m *CoreServiceTypes_GetEntitiesRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CoreServiceTypes_GetEntitiesRequest.Unmarshal(m, b)
@@ -104,7 +104,7 @@ func (m *CoreServiceTypes_GetEntitiesResponse) Reset()         { *m = CoreServic
 func (m *CoreServiceTypes_GetEntitiesResponse) String() string { return proto.CompactTextString(m) }
 func (*CoreServiceTypes_GetEntitiesResponse) ProtoMessage()    {}
 func (*CoreServiceTypes_GetEntitiesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_CoreService_aeabad36f2a7449f, []int{0, 1}
+	return fileDescriptor_CoreService_ab3e56c9944743b5, []int{0, 1}
 }
 func (m *CoreServiceTypes_GetEntitiesResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CoreServiceTypes_GetEntitiesResponse.Unmarshal(m, b)
@@ -142,7 +142,7 @@ func (m *CoreServiceTypes_ListEntitiesResponse) Reset()         { *m = CoreServi
 func (m *CoreServiceTypes_ListEntitiesResponse) String() string { return proto.CompactTextString(m) }
 func (*CoreServiceTypes_ListEntitiesResponse) ProtoMessage()    {}
 func (*CoreServiceTypes_ListEntitiesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_CoreService_aeabad36f2a7449f, []int{0, 2}
+	return fileDescriptor_CoreService_ab3e56c9944743b5, []int{0, 2}
 }
 func (m *CoreServiceTypes_ListEntitiesResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CoreServiceTypes_ListEntitiesResponse.Unmarshal(m, b)
@@ -181,7 +181,7 @@ func (m *CoreServiceTypes_GetFeaturesRequest) Reset()         { *m = CoreService
 func (m *CoreServiceTypes_GetFeaturesRequest) String() string { return proto.CompactTextString(m) }
 func (*CoreServiceTypes_GetFeaturesRequest) ProtoMessage()    {}
 func (*CoreServiceTypes_GetFeaturesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_CoreService_aeabad36f2a7449f, []int{0, 3}
+	return fileDescriptor_CoreService_ab3e56c9944743b5, []int{0, 3}
 }
 func (m *CoreServiceTypes_GetFeaturesRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CoreServiceTypes_GetFeaturesRequest.Unmarshal(m, b)
@@ -219,7 +219,7 @@ func (m *CoreServiceTypes_GetFeaturesResponse) Reset()         { *m = CoreServic
 func (m *CoreServiceTypes_GetFeaturesResponse) String() string { return proto.CompactTextString(m) }
 func (*CoreServiceTypes_GetFeaturesResponse) ProtoMessage()    {}
 func (*CoreServiceTypes_GetFeaturesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_CoreService_aeabad36f2a7449f, []int{0, 4}
+	return fileDescriptor_CoreService_ab3e56c9944743b5, []int{0, 4}
 }
 func (m *CoreServiceTypes_GetFeaturesResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CoreServiceTypes_GetFeaturesResponse.Unmarshal(m, b)
@@ -257,7 +257,7 @@ func (m *CoreServiceTypes_ListFeaturesResponse) Reset()         { *m = CoreServi
 func (m *CoreServiceTypes_ListFeaturesResponse) String() string { return proto.CompactTextString(m) }
 func (*CoreServiceTypes_ListFeaturesResponse) ProtoMessage()    {}
 func (*CoreServiceTypes_ListFeaturesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_CoreService_aeabad36f2a7449f, []int{0, 5}
+	return fileDescriptor_CoreService_ab3e56c9944743b5, []int{0, 5}
 }
 func (m *CoreServiceTypes_ListFeaturesResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CoreServiceTypes_ListFeaturesResponse.Unmarshal(m, b)
@@ -296,7 +296,7 @@ func (m *CoreServiceTypes_GetStorageRequest) Reset()         { *m = CoreServiceT
 func (m *CoreServiceTypes_GetStorageRequest) String() string { return proto.CompactTextString(m) }
 func (*CoreServiceTypes_GetStorageRequest) ProtoMessage()    {}
 func (*CoreServiceTypes_GetStorageRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_CoreService_aeabad36f2a7449f, []int{0, 6}
+	return fileDescriptor_CoreService_ab3e56c9944743b5, []int{0, 6}
 }
 func (m *CoreServiceTypes_GetStorageRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CoreServiceTypes_GetStorageRequest.Unmarshal(m, b)
@@ -334,7 +334,7 @@ func (m *CoreServiceTypes_GetStorageResponse) Reset()         { *m = CoreService
 func (m *CoreServiceTypes_GetStorageResponse) String() string { return proto.CompactTextString(m) }
 func (*CoreServiceTypes_GetStorageResponse) ProtoMessage()    {}
 func (*CoreServiceTypes_GetStorageResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_CoreService_aeabad36f2a7449f, []int{0, 7}
+	return fileDescriptor_CoreService_ab3e56c9944743b5, []int{0, 7}
 }
 func (m *CoreServiceTypes_GetStorageResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CoreServiceTypes_GetStorageResponse.Unmarshal(m, b)
@@ -372,7 +372,7 @@ func (m *CoreServiceTypes_ListStorageResponse) Reset()         { *m = CoreServic
 func (m *CoreServiceTypes_ListStorageResponse) String() string { return proto.CompactTextString(m) }
 func (*CoreServiceTypes_ListStorageResponse) ProtoMessage()    {}
 func (*CoreServiceTypes_ListStorageResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_CoreService_aeabad36f2a7449f, []int{0, 8}
+	return fileDescriptor_CoreService_ab3e56c9944743b5, []int{0, 8}
 }
 func (m *CoreServiceTypes_ListStorageResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CoreServiceTypes_ListStorageResponse.Unmarshal(m, b)
@@ -400,40 +400,38 @@ func (m *CoreServiceTypes_ListStorageResponse) GetStorageSpecs() []*specs.Storag
 }
 
 // Entity registration response
-type CoreServiceTypes_RegisterEntityResponse struct {
+type CoreServiceTypes_ApplyEntityResponse struct {
 	EntityName           string   `protobuf:"bytes,1,opt,name=entityName,proto3" json:"entityName,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *CoreServiceTypes_RegisterEntityResponse) Reset() {
-	*m = CoreServiceTypes_RegisterEntityResponse{}
+func (m *CoreServiceTypes_ApplyEntityResponse) Reset()         { *m = CoreServiceTypes_ApplyEntityResponse{} }
+func (m *CoreServiceTypes_ApplyEntityResponse) String() string { return proto.CompactTextString(m) }
+func (*CoreServiceTypes_ApplyEntityResponse) ProtoMessage()    {}
+func (*CoreServiceTypes_ApplyEntityResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_CoreService_ab3e56c9944743b5, []int{0, 9}
 }
-func (m *CoreServiceTypes_RegisterEntityResponse) String() string { return proto.CompactTextString(m) }
-func (*CoreServiceTypes_RegisterEntityResponse) ProtoMessage()    {}
-func (*CoreServiceTypes_RegisterEntityResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_CoreService_aeabad36f2a7449f, []int{0, 9}
+func (m *CoreServiceTypes_ApplyEntityResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_CoreServiceTypes_ApplyEntityResponse.Unmarshal(m, b)
 }
-func (m *CoreServiceTypes_RegisterEntityResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_CoreServiceTypes_RegisterEntityResponse.Unmarshal(m, b)
+func (m *CoreServiceTypes_ApplyEntityResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_CoreServiceTypes_ApplyEntityResponse.Marshal(b, m, deterministic)
 }
-func (m *CoreServiceTypes_RegisterEntityResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_CoreServiceTypes_RegisterEntityResponse.Marshal(b, m, deterministic)
+func (dst *CoreServiceTypes_ApplyEntityResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CoreServiceTypes_ApplyEntityResponse.Merge(dst, src)
 }
-func (dst *CoreServiceTypes_RegisterEntityResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CoreServiceTypes_RegisterEntityResponse.Merge(dst, src)
+func (m *CoreServiceTypes_ApplyEntityResponse) XXX_Size() int {
+	return xxx_messageInfo_CoreServiceTypes_ApplyEntityResponse.Size(m)
 }
-func (m *CoreServiceTypes_RegisterEntityResponse) XXX_Size() int {
-	return xxx_messageInfo_CoreServiceTypes_RegisterEntityResponse.Size(m)
-}
-func (m *CoreServiceTypes_RegisterEntityResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_CoreServiceTypes_RegisterEntityResponse.DiscardUnknown(m)
+func (m *CoreServiceTypes_ApplyEntityResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_CoreServiceTypes_ApplyEntityResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_CoreServiceTypes_RegisterEntityResponse proto.InternalMessageInfo
+var xxx_messageInfo_CoreServiceTypes_ApplyEntityResponse proto.InternalMessageInfo
 
-func (m *CoreServiceTypes_RegisterEntityResponse) GetEntityName() string {
+func (m *CoreServiceTypes_ApplyEntityResponse) GetEntityName() string {
 	if m != nil {
 		return m.EntityName
 	}
@@ -441,40 +439,38 @@ func (m *CoreServiceTypes_RegisterEntityResponse) GetEntityName() string {
 }
 
 // Feature registration response
-type CoreServiceTypes_RegisterFeatureResponse struct {
+type CoreServiceTypes_ApplyFeatureResponse struct {
 	FeatureId            string   `protobuf:"bytes,1,opt,name=featureId,proto3" json:"featureId,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *CoreServiceTypes_RegisterFeatureResponse) Reset() {
-	*m = CoreServiceTypes_RegisterFeatureResponse{}
+func (m *CoreServiceTypes_ApplyFeatureResponse) Reset()         { *m = CoreServiceTypes_ApplyFeatureResponse{} }
+func (m *CoreServiceTypes_ApplyFeatureResponse) String() string { return proto.CompactTextString(m) }
+func (*CoreServiceTypes_ApplyFeatureResponse) ProtoMessage()    {}
+func (*CoreServiceTypes_ApplyFeatureResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_CoreService_ab3e56c9944743b5, []int{0, 10}
 }
-func (m *CoreServiceTypes_RegisterFeatureResponse) String() string { return proto.CompactTextString(m) }
-func (*CoreServiceTypes_RegisterFeatureResponse) ProtoMessage()    {}
-func (*CoreServiceTypes_RegisterFeatureResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_CoreService_aeabad36f2a7449f, []int{0, 10}
+func (m *CoreServiceTypes_ApplyFeatureResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_CoreServiceTypes_ApplyFeatureResponse.Unmarshal(m, b)
 }
-func (m *CoreServiceTypes_RegisterFeatureResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_CoreServiceTypes_RegisterFeatureResponse.Unmarshal(m, b)
+func (m *CoreServiceTypes_ApplyFeatureResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_CoreServiceTypes_ApplyFeatureResponse.Marshal(b, m, deterministic)
 }
-func (m *CoreServiceTypes_RegisterFeatureResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_CoreServiceTypes_RegisterFeatureResponse.Marshal(b, m, deterministic)
+func (dst *CoreServiceTypes_ApplyFeatureResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CoreServiceTypes_ApplyFeatureResponse.Merge(dst, src)
 }
-func (dst *CoreServiceTypes_RegisterFeatureResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CoreServiceTypes_RegisterFeatureResponse.Merge(dst, src)
+func (m *CoreServiceTypes_ApplyFeatureResponse) XXX_Size() int {
+	return xxx_messageInfo_CoreServiceTypes_ApplyFeatureResponse.Size(m)
 }
-func (m *CoreServiceTypes_RegisterFeatureResponse) XXX_Size() int {
-	return xxx_messageInfo_CoreServiceTypes_RegisterFeatureResponse.Size(m)
-}
-func (m *CoreServiceTypes_RegisterFeatureResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_CoreServiceTypes_RegisterFeatureResponse.DiscardUnknown(m)
+func (m *CoreServiceTypes_ApplyFeatureResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_CoreServiceTypes_ApplyFeatureResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_CoreServiceTypes_RegisterFeatureResponse proto.InternalMessageInfo
+var xxx_messageInfo_CoreServiceTypes_ApplyFeatureResponse proto.InternalMessageInfo
 
-func (m *CoreServiceTypes_RegisterFeatureResponse) GetFeatureId() string {
+func (m *CoreServiceTypes_ApplyFeatureResponse) GetFeatureId() string {
 	if m != nil {
 		return m.FeatureId
 	}
@@ -482,42 +478,42 @@ func (m *CoreServiceTypes_RegisterFeatureResponse) GetFeatureId() string {
 }
 
 // Feature group registration response
-type CoreServiceTypes_RegisterFeatureGroupResponse struct {
+type CoreServiceTypes_ApplyFeatureGroupResponse struct {
 	FeatureGroupId       string   `protobuf:"bytes,1,opt,name=featureGroupId,proto3" json:"featureGroupId,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *CoreServiceTypes_RegisterFeatureGroupResponse) Reset() {
-	*m = CoreServiceTypes_RegisterFeatureGroupResponse{}
+func (m *CoreServiceTypes_ApplyFeatureGroupResponse) Reset() {
+	*m = CoreServiceTypes_ApplyFeatureGroupResponse{}
 }
-func (m *CoreServiceTypes_RegisterFeatureGroupResponse) String() string {
+func (m *CoreServiceTypes_ApplyFeatureGroupResponse) String() string {
 	return proto.CompactTextString(m)
 }
-func (*CoreServiceTypes_RegisterFeatureGroupResponse) ProtoMessage() {}
-func (*CoreServiceTypes_RegisterFeatureGroupResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_CoreService_aeabad36f2a7449f, []int{0, 11}
+func (*CoreServiceTypes_ApplyFeatureGroupResponse) ProtoMessage() {}
+func (*CoreServiceTypes_ApplyFeatureGroupResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_CoreService_ab3e56c9944743b5, []int{0, 11}
 }
-func (m *CoreServiceTypes_RegisterFeatureGroupResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_CoreServiceTypes_RegisterFeatureGroupResponse.Unmarshal(m, b)
+func (m *CoreServiceTypes_ApplyFeatureGroupResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_CoreServiceTypes_ApplyFeatureGroupResponse.Unmarshal(m, b)
 }
-func (m *CoreServiceTypes_RegisterFeatureGroupResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_CoreServiceTypes_RegisterFeatureGroupResponse.Marshal(b, m, deterministic)
+func (m *CoreServiceTypes_ApplyFeatureGroupResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_CoreServiceTypes_ApplyFeatureGroupResponse.Marshal(b, m, deterministic)
 }
-func (dst *CoreServiceTypes_RegisterFeatureGroupResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CoreServiceTypes_RegisterFeatureGroupResponse.Merge(dst, src)
+func (dst *CoreServiceTypes_ApplyFeatureGroupResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CoreServiceTypes_ApplyFeatureGroupResponse.Merge(dst, src)
 }
-func (m *CoreServiceTypes_RegisterFeatureGroupResponse) XXX_Size() int {
-	return xxx_messageInfo_CoreServiceTypes_RegisterFeatureGroupResponse.Size(m)
+func (m *CoreServiceTypes_ApplyFeatureGroupResponse) XXX_Size() int {
+	return xxx_messageInfo_CoreServiceTypes_ApplyFeatureGroupResponse.Size(m)
 }
-func (m *CoreServiceTypes_RegisterFeatureGroupResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_CoreServiceTypes_RegisterFeatureGroupResponse.DiscardUnknown(m)
+func (m *CoreServiceTypes_ApplyFeatureGroupResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_CoreServiceTypes_ApplyFeatureGroupResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_CoreServiceTypes_RegisterFeatureGroupResponse proto.InternalMessageInfo
+var xxx_messageInfo_CoreServiceTypes_ApplyFeatureGroupResponse proto.InternalMessageInfo
 
-func (m *CoreServiceTypes_RegisterFeatureGroupResponse) GetFeatureGroupId() string {
+func (m *CoreServiceTypes_ApplyFeatureGroupResponse) GetFeatureGroupId() string {
 	if m != nil {
 		return m.FeatureGroupId
 	}
@@ -525,40 +521,38 @@ func (m *CoreServiceTypes_RegisterFeatureGroupResponse) GetFeatureGroupId() stri
 }
 
 // Storage registration response
-type CoreServiceTypes_RegisterStorageResponse struct {
+type CoreServiceTypes_ApplyStorageResponse struct {
 	StorageId            string   `protobuf:"bytes,1,opt,name=storageId,proto3" json:"storageId,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *CoreServiceTypes_RegisterStorageResponse) Reset() {
-	*m = CoreServiceTypes_RegisterStorageResponse{}
+func (m *CoreServiceTypes_ApplyStorageResponse) Reset()         { *m = CoreServiceTypes_ApplyStorageResponse{} }
+func (m *CoreServiceTypes_ApplyStorageResponse) String() string { return proto.CompactTextString(m) }
+func (*CoreServiceTypes_ApplyStorageResponse) ProtoMessage()    {}
+func (*CoreServiceTypes_ApplyStorageResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_CoreService_ab3e56c9944743b5, []int{0, 12}
 }
-func (m *CoreServiceTypes_RegisterStorageResponse) String() string { return proto.CompactTextString(m) }
-func (*CoreServiceTypes_RegisterStorageResponse) ProtoMessage()    {}
-func (*CoreServiceTypes_RegisterStorageResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_CoreService_aeabad36f2a7449f, []int{0, 12}
+func (m *CoreServiceTypes_ApplyStorageResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_CoreServiceTypes_ApplyStorageResponse.Unmarshal(m, b)
 }
-func (m *CoreServiceTypes_RegisterStorageResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_CoreServiceTypes_RegisterStorageResponse.Unmarshal(m, b)
+func (m *CoreServiceTypes_ApplyStorageResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_CoreServiceTypes_ApplyStorageResponse.Marshal(b, m, deterministic)
 }
-func (m *CoreServiceTypes_RegisterStorageResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_CoreServiceTypes_RegisterStorageResponse.Marshal(b, m, deterministic)
+func (dst *CoreServiceTypes_ApplyStorageResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CoreServiceTypes_ApplyStorageResponse.Merge(dst, src)
 }
-func (dst *CoreServiceTypes_RegisterStorageResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CoreServiceTypes_RegisterStorageResponse.Merge(dst, src)
+func (m *CoreServiceTypes_ApplyStorageResponse) XXX_Size() int {
+	return xxx_messageInfo_CoreServiceTypes_ApplyStorageResponse.Size(m)
 }
-func (m *CoreServiceTypes_RegisterStorageResponse) XXX_Size() int {
-	return xxx_messageInfo_CoreServiceTypes_RegisterStorageResponse.Size(m)
-}
-func (m *CoreServiceTypes_RegisterStorageResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_CoreServiceTypes_RegisterStorageResponse.DiscardUnknown(m)
+func (m *CoreServiceTypes_ApplyStorageResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_CoreServiceTypes_ApplyStorageResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_CoreServiceTypes_RegisterStorageResponse proto.InternalMessageInfo
+var xxx_messageInfo_CoreServiceTypes_ApplyStorageResponse proto.InternalMessageInfo
 
-func (m *CoreServiceTypes_RegisterStorageResponse) GetStorageId() string {
+func (m *CoreServiceTypes_ApplyStorageResponse) GetStorageId() string {
 	if m != nil {
 		return m.StorageId
 	}
@@ -576,10 +570,10 @@ func init() {
 	proto.RegisterType((*CoreServiceTypes_GetStorageRequest)(nil), "feast.core.CoreServiceTypes.GetStorageRequest")
 	proto.RegisterType((*CoreServiceTypes_GetStorageResponse)(nil), "feast.core.CoreServiceTypes.GetStorageResponse")
 	proto.RegisterType((*CoreServiceTypes_ListStorageResponse)(nil), "feast.core.CoreServiceTypes.ListStorageResponse")
-	proto.RegisterType((*CoreServiceTypes_RegisterEntityResponse)(nil), "feast.core.CoreServiceTypes.RegisterEntityResponse")
-	proto.RegisterType((*CoreServiceTypes_RegisterFeatureResponse)(nil), "feast.core.CoreServiceTypes.RegisterFeatureResponse")
-	proto.RegisterType((*CoreServiceTypes_RegisterFeatureGroupResponse)(nil), "feast.core.CoreServiceTypes.RegisterFeatureGroupResponse")
-	proto.RegisterType((*CoreServiceTypes_RegisterStorageResponse)(nil), "feast.core.CoreServiceTypes.RegisterStorageResponse")
+	proto.RegisterType((*CoreServiceTypes_ApplyEntityResponse)(nil), "feast.core.CoreServiceTypes.ApplyEntityResponse")
+	proto.RegisterType((*CoreServiceTypes_ApplyFeatureResponse)(nil), "feast.core.CoreServiceTypes.ApplyFeatureResponse")
+	proto.RegisterType((*CoreServiceTypes_ApplyFeatureGroupResponse)(nil), "feast.core.CoreServiceTypes.ApplyFeatureGroupResponse")
+	proto.RegisterType((*CoreServiceTypes_ApplyStorageResponse)(nil), "feast.core.CoreServiceTypes.ApplyStorageResponse")
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -619,21 +613,21 @@ type CoreServiceClient interface {
 	// This process returns a list of storage specs.
 	ListStorage(ctx context.Context, in *empty.Empty, opts ...grpc.CallOption) (*CoreServiceTypes_ListStorageResponse, error)
 	//
-	// Register a new feature to the metadata store.
+	// Register a new feature to the metadata store, or update an existing feature.
 	// If any validation errors occur, only the first encountered error will be returned.
-	RegisterFeature(ctx context.Context, in *specs.FeatureSpec, opts ...grpc.CallOption) (*CoreServiceTypes_RegisterFeatureResponse, error)
+	ApplyFeature(ctx context.Context, in *specs.FeatureSpec, opts ...grpc.CallOption) (*CoreServiceTypes_ApplyFeatureResponse, error)
 	//
-	// Register a new feature group to the metadata store.
+	// Register a new feature group to the metadata store, or update an existing feature group.
 	// If any validation errors occur, only the first encountered error will be returned.
-	RegisterFeatureGroup(ctx context.Context, in *specs.FeatureGroupSpec, opts ...grpc.CallOption) (*CoreServiceTypes_RegisterFeatureGroupResponse, error)
+	ApplyFeatureGroup(ctx context.Context, in *specs.FeatureGroupSpec, opts ...grpc.CallOption) (*CoreServiceTypes_ApplyFeatureGroupResponse, error)
 	//
-	// Register a new entity to the metadata store.
+	// Register a new entity to the metadata store, or update an existing entity.
 	// If any validation errors occur, only the first encountered error will be returned.
-	RegisterEntity(ctx context.Context, in *specs.EntitySpec, opts ...grpc.CallOption) (*CoreServiceTypes_RegisterEntityResponse, error)
+	ApplyEntity(ctx context.Context, in *specs.EntitySpec, opts ...grpc.CallOption) (*CoreServiceTypes_ApplyEntityResponse, error)
 	//
-	// Register a new storage spec to the metadata store.
+	// Register a new storage spec to the metadata store, or update an existing storage.
 	// If any validation errors occur, only the first encountered error will be returned.
-	RegisterStorage(ctx context.Context, in *specs.StorageSpec, opts ...grpc.CallOption) (*CoreServiceTypes_RegisterStorageResponse, error)
+	ApplyStorage(ctx context.Context, in *specs.StorageSpec, opts ...grpc.CallOption) (*CoreServiceTypes_ApplyStorageResponse, error)
 }
 
 type coreServiceClient struct {
@@ -698,36 +692,36 @@ func (c *coreServiceClient) ListStorage(ctx context.Context, in *empty.Empty, op
 	return out, nil
 }
 
-func (c *coreServiceClient) RegisterFeature(ctx context.Context, in *specs.FeatureSpec, opts ...grpc.CallOption) (*CoreServiceTypes_RegisterFeatureResponse, error) {
-	out := new(CoreServiceTypes_RegisterFeatureResponse)
-	err := c.cc.Invoke(ctx, "/feast.core.CoreService/RegisterFeature", in, out, opts...)
+func (c *coreServiceClient) ApplyFeature(ctx context.Context, in *specs.FeatureSpec, opts ...grpc.CallOption) (*CoreServiceTypes_ApplyFeatureResponse, error) {
+	out := new(CoreServiceTypes_ApplyFeatureResponse)
+	err := c.cc.Invoke(ctx, "/feast.core.CoreService/ApplyFeature", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *coreServiceClient) RegisterFeatureGroup(ctx context.Context, in *specs.FeatureGroupSpec, opts ...grpc.CallOption) (*CoreServiceTypes_RegisterFeatureGroupResponse, error) {
-	out := new(CoreServiceTypes_RegisterFeatureGroupResponse)
-	err := c.cc.Invoke(ctx, "/feast.core.CoreService/RegisterFeatureGroup", in, out, opts...)
+func (c *coreServiceClient) ApplyFeatureGroup(ctx context.Context, in *specs.FeatureGroupSpec, opts ...grpc.CallOption) (*CoreServiceTypes_ApplyFeatureGroupResponse, error) {
+	out := new(CoreServiceTypes_ApplyFeatureGroupResponse)
+	err := c.cc.Invoke(ctx, "/feast.core.CoreService/ApplyFeatureGroup", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *coreServiceClient) RegisterEntity(ctx context.Context, in *specs.EntitySpec, opts ...grpc.CallOption) (*CoreServiceTypes_RegisterEntityResponse, error) {
-	out := new(CoreServiceTypes_RegisterEntityResponse)
-	err := c.cc.Invoke(ctx, "/feast.core.CoreService/RegisterEntity", in, out, opts...)
+func (c *coreServiceClient) ApplyEntity(ctx context.Context, in *specs.EntitySpec, opts ...grpc.CallOption) (*CoreServiceTypes_ApplyEntityResponse, error) {
+	out := new(CoreServiceTypes_ApplyEntityResponse)
+	err := c.cc.Invoke(ctx, "/feast.core.CoreService/ApplyEntity", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *coreServiceClient) RegisterStorage(ctx context.Context, in *specs.StorageSpec, opts ...grpc.CallOption) (*CoreServiceTypes_RegisterStorageResponse, error) {
-	out := new(CoreServiceTypes_RegisterStorageResponse)
-	err := c.cc.Invoke(ctx, "/feast.core.CoreService/RegisterStorage", in, out, opts...)
+func (c *coreServiceClient) ApplyStorage(ctx context.Context, in *specs.StorageSpec, opts ...grpc.CallOption) (*CoreServiceTypes_ApplyStorageResponse, error) {
+	out := new(CoreServiceTypes_ApplyStorageResponse)
+	err := c.cc.Invoke(ctx, "/feast.core.CoreService/ApplyStorage", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -761,21 +755,21 @@ type CoreServiceServer interface {
 	// This process returns a list of storage specs.
 	ListStorage(context.Context, *empty.Empty) (*CoreServiceTypes_ListStorageResponse, error)
 	//
-	// Register a new feature to the metadata store.
+	// Register a new feature to the metadata store, or update an existing feature.
 	// If any validation errors occur, only the first encountered error will be returned.
-	RegisterFeature(context.Context, *specs.FeatureSpec) (*CoreServiceTypes_RegisterFeatureResponse, error)
+	ApplyFeature(context.Context, *specs.FeatureSpec) (*CoreServiceTypes_ApplyFeatureResponse, error)
 	//
-	// Register a new feature group to the metadata store.
+	// Register a new feature group to the metadata store, or update an existing feature group.
 	// If any validation errors occur, only the first encountered error will be returned.
-	RegisterFeatureGroup(context.Context, *specs.FeatureGroupSpec) (*CoreServiceTypes_RegisterFeatureGroupResponse, error)
+	ApplyFeatureGroup(context.Context, *specs.FeatureGroupSpec) (*CoreServiceTypes_ApplyFeatureGroupResponse, error)
 	//
-	// Register a new entity to the metadata store.
+	// Register a new entity to the metadata store, or update an existing entity.
 	// If any validation errors occur, only the first encountered error will be returned.
-	RegisterEntity(context.Context, *specs.EntitySpec) (*CoreServiceTypes_RegisterEntityResponse, error)
+	ApplyEntity(context.Context, *specs.EntitySpec) (*CoreServiceTypes_ApplyEntityResponse, error)
 	//
-	// Register a new storage spec to the metadata store.
+	// Register a new storage spec to the metadata store, or update an existing storage.
 	// If any validation errors occur, only the first encountered error will be returned.
-	RegisterStorage(context.Context, *specs.StorageSpec) (*CoreServiceTypes_RegisterStorageResponse, error)
+	ApplyStorage(context.Context, *specs.StorageSpec) (*CoreServiceTypes_ApplyStorageResponse, error)
 }
 
 func RegisterCoreServiceServer(s *grpc.Server, srv CoreServiceServer) {
@@ -890,74 +884,74 @@ func _CoreService_ListStorage_Handler(srv interface{}, ctx context.Context, dec 
 	return interceptor(ctx, in, info, handler)
 }
 
-func _CoreService_RegisterFeature_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _CoreService_ApplyFeature_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(specs.FeatureSpec)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(CoreServiceServer).RegisterFeature(ctx, in)
+		return srv.(CoreServiceServer).ApplyFeature(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/feast.core.CoreService/RegisterFeature",
+		FullMethod: "/feast.core.CoreService/ApplyFeature",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(CoreServiceServer).RegisterFeature(ctx, req.(*specs.FeatureSpec))
+		return srv.(CoreServiceServer).ApplyFeature(ctx, req.(*specs.FeatureSpec))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _CoreService_RegisterFeatureGroup_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _CoreService_ApplyFeatureGroup_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(specs.FeatureGroupSpec)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(CoreServiceServer).RegisterFeatureGroup(ctx, in)
+		return srv.(CoreServiceServer).ApplyFeatureGroup(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/feast.core.CoreService/RegisterFeatureGroup",
+		FullMethod: "/feast.core.CoreService/ApplyFeatureGroup",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(CoreServiceServer).RegisterFeatureGroup(ctx, req.(*specs.FeatureGroupSpec))
+		return srv.(CoreServiceServer).ApplyFeatureGroup(ctx, req.(*specs.FeatureGroupSpec))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _CoreService_RegisterEntity_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _CoreService_ApplyEntity_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(specs.EntitySpec)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(CoreServiceServer).RegisterEntity(ctx, in)
+		return srv.(CoreServiceServer).ApplyEntity(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/feast.core.CoreService/RegisterEntity",
+		FullMethod: "/feast.core.CoreService/ApplyEntity",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(CoreServiceServer).RegisterEntity(ctx, req.(*specs.EntitySpec))
+		return srv.(CoreServiceServer).ApplyEntity(ctx, req.(*specs.EntitySpec))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _CoreService_RegisterStorage_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _CoreService_ApplyStorage_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(specs.StorageSpec)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(CoreServiceServer).RegisterStorage(ctx, in)
+		return srv.(CoreServiceServer).ApplyStorage(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/feast.core.CoreService/RegisterStorage",
+		FullMethod: "/feast.core.CoreService/ApplyStorage",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(CoreServiceServer).RegisterStorage(ctx, req.(*specs.StorageSpec))
+		return srv.(CoreServiceServer).ApplyStorage(ctx, req.(*specs.StorageSpec))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -991,20 +985,20 @@ var _CoreService_serviceDesc = grpc.ServiceDesc{
 			Handler:    _CoreService_ListStorage_Handler,
 		},
 		{
-			MethodName: "RegisterFeature",
-			Handler:    _CoreService_RegisterFeature_Handler,
+			MethodName: "ApplyFeature",
+			Handler:    _CoreService_ApplyFeature_Handler,
 		},
 		{
-			MethodName: "RegisterFeatureGroup",
-			Handler:    _CoreService_RegisterFeatureGroup_Handler,
+			MethodName: "ApplyFeatureGroup",
+			Handler:    _CoreService_ApplyFeatureGroup_Handler,
 		},
 		{
-			MethodName: "RegisterEntity",
-			Handler:    _CoreService_RegisterEntity_Handler,
+			MethodName: "ApplyEntity",
+			Handler:    _CoreService_ApplyEntity_Handler,
 		},
 		{
-			MethodName: "RegisterStorage",
-			Handler:    _CoreService_RegisterStorage_Handler,
+			MethodName: "ApplyStorage",
+			Handler:    _CoreService_ApplyStorage_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
@@ -1012,47 +1006,47 @@ var _CoreService_serviceDesc = grpc.ServiceDesc{
 }
 
 func init() {
-	proto.RegisterFile("feast/core/CoreService.proto", fileDescriptor_CoreService_aeabad36f2a7449f)
+	proto.RegisterFile("feast/core/CoreService.proto", fileDescriptor_CoreService_ab3e56c9944743b5)
 }
 
-var fileDescriptor_CoreService_aeabad36f2a7449f = []byte{
-	// 605 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xac, 0x56, 0x5f, 0x4f, 0x13, 0x41,
-	0x10, 0x6f, 0x43, 0x42, 0xda, 0x29, 0x41, 0x5c, 0x08, 0x34, 0x6b, 0x31, 0xa4, 0x89, 0x84, 0x17,
-	0xf6, 0x90, 0x36, 0x51, 0x13, 0x9f, 0x30, 0xd0, 0x28, 0xc4, 0x98, 0x2b, 0x2f, 0xea, 0x8b, 0xed,
-	0x31, 0x3d, 0x4e, 0x2d, 0x7b, 0xde, 0x6e, 0x4d, 0xfa, 0x59, 0xfc, 0x66, 0x7e, 0x1a, 0x73, 0x7b,
-	0xdb, 0xbd, 0xbd, 0xeb, 0x5d, 0x5b, 0x49, 0xdf, 0xda, 0xf9, 0xff, 0x9b, 0x99, 0xdf, 0xec, 0x41,
-	0x6b, 0x84, 0x03, 0x21, 0x1d, 0x8f, 0x47, 0xe8, 0xbc, 0xe3, 0x11, 0xf6, 0x31, 0xfa, 0x1d, 0x78,
-	0xc8, 0xc2, 0x88, 0x4b, 0x4e, 0x40, 0x69, 0x59, 0xac, 0xa5, 0xda, 0x52, 0x84, 0xe8, 0x09, 0xe7,
-	0xf2, 0x41, 0x06, 0x72, 0xda, 0x0f, 0xd1, 0x4b, 0x2c, 0xe9, 0xa1, 0xad, 0xbd, 0xc2, 0x81, 0x9c,
-	0x44, 0x68, 0xa9, 0xdb, 0x05, 0xea, 0x5e, 0xc4, 0x27, 0x61, 0x59, 0x88, 0xbe, 0xe4, 0xd1, 0xc0,
-	0xb7, 0x43, 0x3c, 0xf3, 0x39, 0xf7, 0x7f, 0xa2, 0xa3, 0xfe, 0x0d, 0x27, 0x23, 0x07, 0xc7, 0xa1,
-	0x9c, 0x26, 0xca, 0xf6, 0xdf, 0x4d, 0xd8, 0xb1, 0xca, 0xbf, 0x9d, 0x86, 0x28, 0xe8, 0x31, 0x90,
-	0x1e, 0x4a, 0x55, 0x6a, 0x80, 0xc2, 0xc5, 0x5f, 0x13, 0x14, 0x92, 0xec, 0xc0, 0x46, 0x70, 0x27,
-	0x9a, 0xd5, 0xa3, 0x8d, 0x93, 0xba, 0x1b, 0xff, 0xa4, 0x1f, 0x60, 0x37, 0x63, 0x27, 0x42, 0xfe,
-	0x20, 0x90, 0x74, 0xa0, 0x86, 0x5a, 0xa6, 0xac, 0x1b, 0xe7, 0x07, 0x2c, 0xe9, 0x87, 0x2a, 0x91,
-	0xa5, 0x3d, 0x70, 0x8d, 0x21, 0xbd, 0x86, 0xbd, 0x9b, 0x40, 0xac, 0x29, 0x58, 0x02, 0x40, 0xb7,
-	0x6b, 0x01, 0x80, 0x6b, 0x05, 0x20, 0xb5, 0xd3, 0x39, 0xbb, 0x50, 0x1b, 0x69, 0x99, 0xce, 0xd9,
-	0xcc, 0xe4, 0xb4, 0xc6, 0xe4, 0x1a, 0x4b, 0x7a, 0x93, 0x20, 0x58, 0x53, 0xb4, 0x17, 0xf0, 0xb4,
-	0x87, 0x52, 0x4f, 0xb3, 0x1c, 0x81, 0xab, 0x90, 0x1a, 0x33, 0x9d, 0xf2, 0x2d, 0x6c, 0x89, 0x74,
-	0x0f, 0x8a, 0xd3, 0x5a, 0x8b, 0xe2, 0x66, 0xac, 0x69, 0x1f, 0x76, 0x63, 0x20, 0xeb, 0x0d, 0xfa,
-	0x1a, 0xf6, 0x5d, 0xf4, 0x03, 0x21, 0x31, 0x4a, 0x46, 0x66, 0xe2, 0x3e, 0x07, 0x50, 0x83, 0x9b,
-	0x7e, 0x1c, 0x8c, 0xb1, 0x59, 0x3d, 0xaa, 0x9e, 0xd4, 0x5d, 0x4b, 0x42, 0x5f, 0xc1, 0xc1, 0xcc,
-	0x53, 0xb7, 0xca, 0xb8, 0xb6, 0xa0, 0xae, 0x1b, 0xf6, 0xfe, 0x4e, 0x7b, 0xa6, 0x02, 0x7a, 0x05,
-	0xad, 0x9c, 0xa3, 0x62, 0x8e, 0xf1, 0x3e, 0x86, 0xed, 0x91, 0x25, 0x37, 0x21, 0x72, 0x52, 0xbb,
-	0x80, 0x7c, 0x4f, 0x5a, 0x50, 0xd7, 0x28, 0xd3, 0x02, 0x8c, 0xe0, 0xfc, 0x4f, 0x0d, 0x1a, 0x16,
-	0xb9, 0x48, 0x04, 0x0d, 0x8b, 0x2f, 0xc4, 0x61, 0xe9, 0x95, 0x60, 0x79, 0x12, 0xb2, 0x79, 0x06,
-	0xd2, 0xb3, 0xd5, 0x1d, 0x92, 0xfa, 0xda, 0x15, 0xf2, 0x15, 0xb6, 0x6c, 0x5e, 0x91, 0x7d, 0x96,
-	0x9c, 0x03, 0x36, 0x3b, 0x07, 0xec, 0x32, 0x3e, 0x07, 0xf4, 0xe5, 0xc2, 0xd8, 0x45, 0xd4, 0x6c,
-	0x57, 0x34, 0xa0, 0xd9, 0xc6, 0x2f, 0x07, 0x94, 0x63, 0xe4, 0x72, 0x40, 0x79, 0x32, 0xa5, 0x80,
-	0x4c, 0xd2, 0xc7, 0x03, 0x2a, 0x08, 0xce, 0x01, 0x52, 0x3a, 0x11, 0xb6, 0xac, 0xbc, 0x2c, 0x3d,
-	0xa9, 0xb3, 0xb2, 0xbd, 0x49, 0xf8, 0x19, 0x1a, 0x16, 0xd7, 0x4a, 0xc1, 0x9c, 0x2d, 0x05, 0x33,
-	0x1f, 0xda, 0x83, 0x27, 0xb9, 0xf5, 0x27, 0xa5, 0x87, 0x87, 0x76, 0x17, 0x26, 0x28, 0xe1, 0x9f,
-	0xda, 0x80, 0xbd, 0x22, 0x8e, 0x91, 0xc3, 0xa2, 0x4c, 0xe6, 0xe1, 0xa2, 0x6f, 0xfe, 0x27, 0x5d,
-	0x86, 0xb5, 0xed, 0x0a, 0xf9, 0x06, 0xdb, 0xd9, 0x53, 0x42, 0xca, 0x9e, 0x04, 0xda, 0x59, 0x29,
-	0x4f, 0xf6, 0x20, 0x65, 0x5b, 0x37, 0x9b, 0x4c, 0xe9, 0x9d, 0x5b, 0xb1, 0x75, 0x73, 0xf3, 0xb9,
-	0xb8, 0x05, 0xeb, 0x2b, 0xe1, 0xc2, 0x7e, 0x85, 0x3f, 0xc5, 0xc3, 0xff, 0xd2, 0xf5, 0x03, 0x79,
-	0x3f, 0x19, 0x32, 0x8f, 0x8f, 0x1d, 0x9f, 0x7f, 0xc7, 0x1f, 0x12, 0xbd, 0x7b, 0x27, 0x79, 0xeb,
-	0x7d, 0x7e, 0xaa, 0x7e, 0x9c, 0xaa, 0x3d, 0x71, 0xd2, 0x6f, 0x91, 0xe1, 0xa6, 0x92, 0x74, 0xfe,
-	0x05, 0x00, 0x00, 0xff, 0xff, 0x78, 0x92, 0x55, 0xe6, 0xa0, 0x08, 0x00, 0x00,
+var fileDescriptor_CoreService_ab3e56c9944743b5 = []byte{
+	// 601 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xac, 0x56, 0xcf, 0x6f, 0xd3, 0x30,
+	0x14, 0x6e, 0x35, 0x69, 0x6a, 0x5f, 0x2b, 0xb4, 0xb9, 0x13, 0x14, 0xd3, 0xa1, 0x29, 0x12, 0xd3,
+	0x2e, 0x73, 0xc6, 0x56, 0x38, 0x71, 0x61, 0xd3, 0xa8, 0x60, 0x13, 0x42, 0xe9, 0x2e, 0x0c, 0x71,
+	0x68, 0xb3, 0xd7, 0x2c, 0xd0, 0xce, 0x21, 0x76, 0x91, 0x7a, 0xe6, 0xff, 0xe3, 0x6f, 0x42, 0x75,
+	0x5c, 0xc7, 0x4d, 0x93, 0xa5, 0x42, 0xbd, 0xb5, 0xef, 0xd7, 0xe7, 0xef, 0x3d, 0x7f, 0xcf, 0x81,
+	0xce, 0x08, 0x07, 0x42, 0xba, 0x3e, 0x8f, 0xd1, 0xbd, 0xe0, 0x31, 0xf6, 0x31, 0xfe, 0x1d, 0xfa,
+	0xc8, 0xa2, 0x98, 0x4b, 0x4e, 0x40, 0x79, 0xd9, 0xdc, 0x4b, 0x75, 0xa4, 0x88, 0xd0, 0x17, 0xee,
+	0xe5, 0x83, 0x0c, 0xe5, 0xac, 0x1f, 0xa1, 0x9f, 0x44, 0xd2, 0x7d, 0xdb, 0xfb, 0x01, 0x07, 0x72,
+	0x1a, 0xa3, 0xe5, 0x76, 0x72, 0xdc, 0xbd, 0x98, 0x4f, 0xa3, 0xa2, 0x12, 0x7d, 0xc9, 0xe3, 0x41,
+	0x60, 0x97, 0x78, 0x11, 0x70, 0x1e, 0x8c, 0xd1, 0x55, 0xff, 0x86, 0xd3, 0x91, 0x8b, 0x93, 0x48,
+	0xce, 0x12, 0xa7, 0xf3, 0x77, 0x1b, 0x76, 0xac, 0xe3, 0xdf, 0xcc, 0x22, 0x14, 0xf4, 0x10, 0x48,
+	0x0f, 0xa5, 0x3a, 0x6a, 0x88, 0xc2, 0xc3, 0x5f, 0x53, 0x14, 0x92, 0xec, 0xc0, 0x56, 0x78, 0x27,
+	0xda, 0xd5, 0x83, 0xad, 0xa3, 0xba, 0x37, 0xff, 0x49, 0x3f, 0x41, 0x6b, 0x29, 0x4e, 0x44, 0xfc,
+	0x41, 0x20, 0x39, 0x83, 0x1a, 0x6a, 0x9b, 0x8a, 0x6e, 0x9c, 0x3e, 0x63, 0x49, 0x3f, 0xd4, 0x11,
+	0x59, 0xda, 0x03, 0xcf, 0x04, 0xd2, 0x2b, 0xd8, 0xbb, 0x0e, 0xc5, 0x86, 0x8a, 0x25, 0x04, 0x74,
+	0xbb, 0x1e, 0x21, 0x70, 0xa5, 0x08, 0xa4, 0x71, 0x1a, 0xb3, 0x0b, 0xb5, 0x91, 0xb6, 0x69, 0xcc,
+	0xf6, 0x12, 0xa6, 0x35, 0x26, 0xcf, 0x44, 0xd2, 0xeb, 0x84, 0xc1, 0x86, 0xaa, 0xbd, 0x82, 0xdd,
+	0x1e, 0x4a, 0x3d, 0xcd, 0x62, 0x06, 0x9e, 0x62, 0x6a, 0xc2, 0x34, 0xe4, 0x3b, 0x68, 0x8a, 0xf4,
+	0x1e, 0xe4, 0xc3, 0x5a, 0x17, 0xc5, 0x5b, 0x8a, 0xa6, 0x7d, 0x68, 0xcd, 0x89, 0x6c, 0xb6, 0xe8,
+	0x1b, 0x68, 0xbd, 0x8f, 0xa2, 0xf1, 0x2c, 0x99, 0x97, 0x29, 0xfa, 0x12, 0x40, 0x4d, 0x6d, 0xf6,
+	0x79, 0x30, 0xc1, 0x76, 0xf5, 0xa0, 0x7a, 0x54, 0xf7, 0x2c, 0x0b, 0xed, 0xc2, 0x9e, 0x4a, 0xd3,
+	0x4d, 0x32, 0x79, 0x1d, 0xa8, 0xeb, 0x56, 0x7d, 0xbc, 0xd3, 0x69, 0xa9, 0x81, 0x5e, 0xc0, 0x73,
+	0x3b, 0x4b, 0x09, 0xc6, 0xa4, 0x1e, 0xc2, 0x93, 0x91, 0x65, 0x37, 0xf9, 0x19, 0xab, 0x81, 0xce,
+	0xf6, 0xa1, 0x03, 0x75, 0xcd, 0x2c, 0x85, 0x36, 0x86, 0xd3, 0x3f, 0x35, 0x68, 0x58, 0x82, 0x22,
+	0x31, 0x34, 0x2c, 0x8d, 0x10, 0x97, 0xa5, 0x9b, 0x81, 0x65, 0x85, 0xc7, 0x56, 0x55, 0x47, 0x4f,
+	0xd6, 0x4f, 0x48, 0xce, 0xe7, 0x54, 0xc8, 0x37, 0x68, 0xda, 0x5a, 0x22, 0x4f, 0x59, 0xb2, 0x02,
+	0xd8, 0x62, 0x05, 0xb0, 0xcb, 0xf9, 0x0a, 0xa0, 0xaf, 0x1f, 0xad, 0x9d, 0x27, 0x47, 0xa7, 0xa2,
+	0x09, 0x2d, 0x6e, 0x79, 0x39, 0xa1, 0x8c, 0x0a, 0xcb, 0x09, 0x65, 0x05, 0x94, 0x12, 0x32, 0xa0,
+	0xff, 0x4f, 0x28, 0xa7, 0x38, 0x07, 0x48, 0x25, 0x44, 0x58, 0xd9, 0xf1, 0x96, 0x25, 0x49, 0xdd,
+	0xb5, 0xe3, 0x0d, 0xe0, 0x57, 0x68, 0x58, 0xfa, 0x2a, 0x24, 0x73, 0x52, 0x4a, 0x66, 0xb5, 0xf4,
+	0x77, 0x68, 0xda, 0x17, 0x9f, 0x14, 0x6e, 0x9a, 0x92, 0x56, 0xe5, 0x69, 0xce, 0xa9, 0x90, 0x31,
+	0xec, 0xae, 0xe8, 0x8a, 0xec, 0xe7, 0x61, 0x98, 0x37, 0x8a, 0xbe, 0x5d, 0x1b, 0x68, 0x49, 0xa6,
+	0x4e, 0x85, 0xdc, 0x42, 0xc3, 0x5a, 0x19, 0xa4, 0x68, 0xef, 0x97, 0x34, 0x2a, 0x67, 0xeb, 0x58,
+	0x8d, 0x5a, 0x0c, 0xa1, 0x70, 0x8d, 0xad, 0xd3, 0xa8, 0x95, 0x39, 0x9c, 0xdf, 0x80, 0xf5, 0x05,
+	0x70, 0x6e, 0xbf, 0xb0, 0x5f, 0xe6, 0x43, 0xbe, 0xed, 0x06, 0xa1, 0xbc, 0x9f, 0x0e, 0x99, 0xcf,
+	0x27, 0x6e, 0xc0, 0x7f, 0xe0, 0x4f, 0x89, 0xfe, 0xbd, 0x9b, 0xbc, 0xe3, 0x01, 0x3f, 0x56, 0x3f,
+	0x8e, 0xd5, 0x7d, 0x70, 0xd3, 0xef, 0x8c, 0xe1, 0xb6, 0xb2, 0x9c, 0xfd, 0x0b, 0x00, 0x00, 0xff,
+	0xff, 0x7f, 0xa2, 0x2d, 0x17, 0x7c, 0x08, 0x00, 0x00,
 }

--- a/protos/feast/core/CoreService.proto
+++ b/protos/feast/core/CoreService.proto
@@ -66,28 +66,28 @@ service CoreService {
     rpc ListStorage(google.protobuf.Empty) returns (CoreServiceTypes.ListStorageResponse) {};
 
     /*
-    Register a new feature to the metadata store.
+    Register a new feature to the metadata store, or update an existing feature.
     If any validation errors occur, only the first encountered error will be returned.
     */
-    rpc RegisterFeature(feast.specs.FeatureSpec) returns (CoreServiceTypes.RegisterFeatureResponse) {};
+    rpc ApplyFeature(feast.specs.FeatureSpec) returns (CoreServiceTypes.ApplyFeatureResponse) {};
 
     /*
-    Register a new feature group to the metadata store.
+    Register a new feature group to the metadata store, or update an existing feature group.
     If any validation errors occur, only the first encountered error will be returned.
     */
-    rpc RegisterFeatureGroup(feast.specs.FeatureGroupSpec) returns (CoreServiceTypes.RegisterFeatureGroupResponse) {};
+    rpc ApplyFeatureGroup(feast.specs.FeatureGroupSpec) returns (CoreServiceTypes.ApplyFeatureGroupResponse) {};
 
     /*
-    Register a new entity to the metadata store.
+    Register a new entity to the metadata store, or update an existing entity.
     If any validation errors occur, only the first encountered error will be returned.
     */
-    rpc RegisterEntity(feast.specs.EntitySpec) returns (CoreServiceTypes.RegisterEntityResponse) {};
+    rpc ApplyEntity(feast.specs.EntitySpec) returns (CoreServiceTypes.ApplyEntityResponse) {};
 
     /*
-    Register a new storage spec to the metadata store.
+    Register a new storage spec to the metadata store, or update an existing storage.
     If any validation errors occur, only the first encountered error will be returned.
     */
-    rpc RegisterStorage(feast.specs.StorageSpec) returns (CoreServiceTypes.RegisterStorageResponse) {};
+    rpc ApplyStorage(feast.specs.StorageSpec) returns (CoreServiceTypes.ApplyStorageResponse) {};
 }
 
 message CoreServiceTypes {
@@ -130,22 +130,22 @@ message CoreServiceTypes {
   }
 
   // Entity registration response
-  message RegisterEntityResponse {
+  message ApplyEntityResponse {
       string entityName = 1;
   }
   
   // Feature registration response
-  message RegisterFeatureResponse {
+  message ApplyFeatureResponse {
       string featureId = 1;
   }
 
   // Feature group registration response
-  message RegisterFeatureGroupResponse {
+  message ApplyFeatureGroupResponse {
       string featureGroupId = 1;
   }
 
   // Storage registration response
-  message RegisterStorageResponse {
+  message ApplyStorageResponse {
       string storageId = 1;
   }
 }


### PR DESCRIPTION
Change register API to apply. 

If you apply a spec for a resource that doesn't already exist in the system, it will be created. If not, then the resource will be updated to match the new spec provided. Note that only fields without dependencies can be updated; i.e. changes to ids, storage sinks, or value types are not allowed. If you apply a spec that has no changes without throwing an error.

Updated the CLI to reflect these changes as well.